### PR TITLE
+feuerherm untested php 8.1 patch

### DIFF
--- a/lib/admin/admin.accounts.addform.php
+++ b/lib/admin/admin.accounts.addform.php
@@ -1,4 +1,4 @@
-            <h3><?php _e('Add a Zotero Account','zotpress'); ?></h3>
+<h3><?php _e('Add a Zotero Account','zotpress'); ?></h3>
 
             <form action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post" id="zp-Add" name="zp-Add">
 

--- a/lib/admin/admin.accounts.oauth.php
+++ b/lib/admin/admin.accounts.oauth.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 
 /** Code provided by and adapted from: http://www.zotero.org/support/dev/server_api/v2/oauth
 	* Note that this example uses the php OAuth extension http://php.net/manual/en/book.oauth.php

--- a/lib/admin/admin.accounts.php
+++ b/lib/admin/admin.accounts.php
@@ -5,9 +5,9 @@ if ( current_user_can('edit_others_posts') )
 {
 
 	// Determine if server supports OAuth
-	if (in_array ('oauth', get_loaded_extensions())) { $oauth_is_not_installed = false; } else { $oauth_is_not_installed = true; }
+	$oauth_is_not_installed = !in_array ('oauth', get_loaded_extensions());
 
-	if (isset( $_GET['oauth'] )) { include("admin.accounts.oauth.php"); } else {
+	if (isset( $_GET['oauth'] )) { include(__DIR__ . "/admin.accounts.oauth.php"); } else {
 
 	?>
 
@@ -47,7 +47,7 @@ if ( current_user_can('edit_others_posts') )
 
 							foreach ($accounts as $num => $account)
 							{
-								if ($num % 2 == 0) { $zebra = " alternate"; } else { $zebra = ""; }
+								$zebra = $num % 2 == 0 ? " alternate" : "";
 
 								$code = "<tr id='zp-Account-" . $account->api_user_id . "' class='zp-Account".$zebra."' rel='" . $account->api_user_id . "'>\n";
 

--- a/lib/admin/admin.browse.php
+++ b/lib/admin/admin.browse.php
@@ -9,50 +9,41 @@
 	// Display Browse page if there's at least one Zotero account synced
     if ( $zp_accounts_total > 0 )
     {
-		if ( isset($_GET['api_user_id']) && preg_match("/^[0-9]+$/", $_GET['api_user_id']) )
-		{
-            $zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$_GET['api_user_id']."'", OBJECT);
-
-            if ( count((array)$zp_account_temp) > 0 )
-            {
+		if (isset($_GET['api_user_id']) && preg_match("/^\\d+\$/", $_GET['api_user_id'])) {
+      $zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$_GET['api_user_id']."'", OBJECT);
+      if ( (array)$zp_account_temp !== [] )
+      {
     			$zp_account = $zp_account_temp;
     			$api_user_id = $zp_account->api_user_id;
-            }
-		}
-		else
-		{
-			if ( get_option("Zotpress_DefaultAccount") )
-			{
-				$zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".get_option("Zotpress_DefaultAccount")."'", OBJECT);
-
-				if ( count((array)$zp_account_temp) > 0 )
-				{
-                    $zp_account = $zp_account_temp;
-					$api_user_id = $zp_account->api_user_id;
-				}
-				else
-				{
-					$zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress LIMIT 1");
-
-					if ( count((array)$zp_account_temp) > 0 )
-					{
-                        $zp_account = $zp_account_temp;
-    					$api_user_id = $zp_account->api_user_id;
-					}
-				}
-			}
-			else
+      }
+  } elseif (get_option("Zotpress_DefaultAccount")) {
+      $zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".get_option("Zotpress_DefaultAccount")."'", OBJECT);
+      if ( (array)$zp_account_temp !== [] )
+  				{
+                      $zp_account = $zp_account_temp;
+  					$api_user_id = $zp_account->api_user_id;
+  				}
+  				else
+  				{
+  					$zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress LIMIT 1");
+  
+  					if ( (array)$zp_account_temp !== [] )
+  					{
+                          $zp_account = $zp_account_temp;
+      					$api_user_id = $zp_account->api_user_id;
+  					}
+  				}
+  } else
 			{
 				$zp_account_temp = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress LIMIT 1");
 
-                if ( ( is_array($zp_account_temp) || is_object($zp_account_temp) || $zp_account_temp instanceof Countable )
-                        && count((array)$zp_account_temp) > 0 )
-                {
-                    $zp_account = $zp_account_temp;
-                    $api_user_id = $zp_account->api_user_id;
+               if ( ( is_array($zp_account_temp) || is_object($zp_account_temp) || $zp_account_temp instanceof Countable )
+                       && (array)$zp_account_temp !== [] )
+               {
+                   $zp_account = $zp_account_temp;
+                   $api_user_id = $zp_account->api_user_id;
 				}
 			}
-		}
 
 
 		// Use Browse class
@@ -127,9 +118,9 @@
 
                     <?php
 
-                    $zp_check_curl = intval( function_exists('curl_version') );
-                    $zp_check_streams = intval( function_exists('stream_get_contents') );
-                    $zp_check_fsock = intval( function_exists('fsockopen') );
+                    $zp_check_curl = (int) function_exists('curl_version');
+                    $zp_check_streams = (int) function_exists('stream_get_contents');
+                    $zp_check_fsock = (int) function_exists('fsockopen');
 
                     if ( ($zp_check_curl + $zp_check_streams + $zp_check_fsock) <= 1 ) { ?>
 

--- a/lib/admin/admin.functions.php
+++ b/lib/admin/admin.functions.php
@@ -69,9 +69,7 @@ function zp_get_accounts($wpdb=false, $use_select=false, $select_req=false, $sel
 				$output .= "</option>\n";
 			}
 
-			$output .= "</select>\n";
-
-			return $output;
+			return $output . "</select>\n";
 		}
 
 	endif; // if $accounts

--- a/lib/admin/admin.help.php
+++ b/lib/admin/admin.help.php
@@ -1,5 +1,4 @@
-
-        <div id="zp-Zotpress" class="wrap">
+<div id="zp-Zotpress" class="wrap">
 
             <?php include( dirname(__FILE__) . '/admin.menu.php' ); ?>
 

--- a/lib/admin/admin.menu.php
+++ b/lib/admin/admin.menu.php
@@ -1,15 +1,14 @@
 <?php
 
-    if ( (isset($_GET['accounts']) && $_GET['accounts'] == "true")
+    if ((isset($_GET['accounts']) && $_GET['accounts'] == "true")
 			|| (isset($_GET['selective']) && $_GET['selective'] == "true")
-			|| (isset($_GET['import']) && $_GET['import'] == "true")
-		)
+			|| (isset($_GET['import']) && $_GET['import'] == "true")) {
         $tagpage = "accounts";
-    else if ( isset($_GET['options']) && $_GET['options'] == "true" )
+    } elseif (isset($_GET['options']) && $_GET['options'] == "true") {
         $tagpage = "options";
-    else if ( isset($_GET['help']) && $_GET['help'] == "true" )
+    } elseif (isset($_GET['help']) && $_GET['help'] == "true") {
         $tagpage = "help";
-    else
+    } else
         $tagpage = "default";
 
 ?>

--- a/lib/admin/admin.options.php
+++ b/lib/admin/admin.options.php
@@ -14,7 +14,7 @@ if ( current_user_can('edit_others_posts') )
 
 				<h3><?php _e('Options','zotpress'); ?></h3>
 
-				<?php include('admin.options.form.php'); ?>
+				<?php include(__DIR__ . '/admin.options.form.php'); ?>
 
 
 				<hr />

--- a/lib/admin/admin.php
+++ b/lib/admin/admin.php
@@ -12,44 +12,15 @@
 
         // SETUP PAGE
 
-        if (isset($_GET['setup']))
-        {
+        if (isset($_GET['setup'])) {
             include( dirname(__FILE__) . '/admin.setup.php' );
-        }
-
-
-
-
-        // ACCOUNTS PAGE
-
-        else if (isset($_GET['accounts']))
-        {
+        } elseif (isset($_GET['accounts'])) {
             include( dirname(__FILE__) . '/admin.accounts.php' );
-        }
-
-
-
-        // OPTIONS PAGE
-
-        else if (isset($_GET['options']))
-        {
+        } elseif (isset($_GET['options'])) {
             include( dirname(__FILE__) . '/admin.options.php' );
-        }
-
-
-
-        // HELP PAGE
-
-        else if (isset($_GET['help']))
-        {
+        } elseif (isset($_GET['help'])) {
             include( dirname(__FILE__) . '/admin.help.php' );
-        }
-
-
-
-        // BROWSE PAGE
-
-        else
+        } else
         {
             include( dirname(__FILE__) . '/admin.browse.php' );
         }
@@ -85,527 +56,382 @@
 
 	   */
 
-		if ( isset($_GET['action_type']) && $_GET['action_type'] == "add_account" )
-		{
-
-			// Set up error array
-			$errors =
-				array(
-					"api_user_id_blank"=>array(0,"<strong>User ID</strong> was left blank."),
-					"api_user_id_format"=>array(0,"<strong>User ID</strong> was formatted incorrectly."),
-					"public_key_blank"=>array(0,"<strong>Public Key</strong> was left blank."),
-					"public_key_format"=>array(0,"<strong>Public Key</strong> was formatted incorrectly."),
-					"nickname_format"=>array(0,"<strong>Nickname</strong> was formatted incorrectly.")
-				);
-
-
-			// Check the post variables and record errors
-
-			// ACCOUNT TYPE
-
-			if ($_GET['account_type'] != "")
-				if ($_GET['account_type'] == "groups")
-					$account_type = "groups";
-				else
-					$account_type = "users";
-			else
-				$account_type = "users";
-
-			// API USER ID
-
-			if ($_GET['api_user_id'] != "")
-				if (preg_match("/^[0-9]+$/", $_GET['api_user_id']) == 1)
-					$api_user_id = htmlentities($_GET['api_user_id']);
-				else
-					$errors['api_user_id_format'][0] = 1;
-			else
-				$errors['api_user_id_blank'][0] = 1;
-
-			// PUBLIC KEY
-
-			$public_key = false;
-			if ($_GET['public_key'] != "")
-				if (preg_match("/^[0-9a-zA-Z]+$/", $_GET['public_key']) == 1)
-					$public_key = htmlentities(trim($_GET['public_key']));
-				else
-					if ($account_type == "users")
-						$errors['public_key_format'][0] = 1;
-			else
-				if ($account_type == "users")
-					$errors['public_key_blank'][0] = 1;
-
-			// NICKNAME
-
-			$nickname = false;
-			if (isset($_GET['nickname']) && trim($_GET['nickname']) != '')
-				if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['nickname'])) == 1)
-					$nickname = str_replace("'", "", str_replace(" ", "", trim(urldecode($_GET['nickname']))));
-				else
-					$errors['nickname_format'][0] = 1;
-
-
-			// CHECK ERRORS
-
-			$errorCheck = false;
-			foreach ($errors as $field => $error) {
-				if ($error[0] == 1) {
-					$errorCheck = true;
-					break;
-				}
-			}
-
-
-			// ADD ACCOUNT
-
-			if ($errorCheck == false)
-			{
-				$query = "INSERT INTO ".$wpdb->prefix."zotpress (account_type, api_user_id, public_key";
-				if ($nickname) $query .= ", nickname";
-				$query .= ") ";
-				$query .= "VALUES ('$account_type', '$api_user_id', '$public_key'";
-				if ($nickname) $query .= ", '$nickname'";
-				$query .= ")";
-
-				// Insert new list item into the list:
-				$wpdb->query($query);
-
-				// Display success XML
-				$xml .= "<result success='true' api_user_id='".$api_user_id."' public_key='".$public_key."' />\n";
-			}
-
-
-			// DISPLAY ERRORS
-
-			else
-			{
-				$xml .= "<result success='false' />\n";
-				$xml .= "<citation>\n";
-				$xml .= "<errors>\n";
-				foreach ($errors as $field => $error)
-					if ($error[0] == 1)
-						$xml .= $error[1]."\n";
-				$xml .= "</errors>\n";
-				$xml .= "</citation>\n";
-			}
-		} // add_account
-
-
-
-		/*
-
-		   REMOVE ACCOUNT
-
-	   */
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "delete_account" )
-		{
-			if (preg_match("/^[0-9]+$/", $_GET['api_user_id']))
-			{
-				$api_user_id = $_GET['api_user_id'];
-
-				// Delete account and items
-				$wpdb->query("DELETE FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$api_user_id."'");
-				zp_clear_cache_for_user ($wpdb, $api_user_id);
-
-				// Check if default account
-				if ( get_option("Zotpress_DefaultAccount") && get_option("Zotpress_DefaultAccount") == $api_user_id )
-					delete_option( "Zotpress_DefaultAccount" );
-
-				$total_accounts = $wpdb->get_var( "SELECT COUNT(*) FROM ".$wpdb->prefix."zotpress;" );
-
-				// Display success XML
-				$xml .= "<result success='true' total_accounts='".$total_accounts."' />\n";
-				$xml .= "<account id='".$api_user_id."' type='delete' />\n";
-
-				$wpdb->flush();
-				unset($api_user_id);
-			}
-			else // die
-			{
-				exit();
-			}
-		}
-
-
-
-		/*
-
-		   CLEAR CACHE FOR ACCOUNT
-
-	   */
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "clear_cache" )
-		{
-			if (preg_match("/^[0-9]+$/", $_GET['api_user_id']))
-			{
-				$api_user_id = $_GET['api_user_id'];
-
-				// Clear the cache
-				zp_clear_cache_for_user ($wpdb, $api_user_id);
-
-				// Display success XML
-				$xml .= "<result success='true' cache_cleared='true' />\n";
-				$xml .= "<account id='".$api_user_id."' type='cache' />\n";
-
-				$wpdb->flush();
-				unset($api_user_id);
-			}
-			else // die
-			{
-				exit();
-			}
-		}
-
-
-
-		/*
-
-		   SET ACCOUNT TO DEFAULT
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "default_account" )
-		{
-			$errors = array("account_empty"=>array(0,"<strong>Account</strong> was left blank."),
-							"account_format"=>array(0,"<strong>Account</strong> was incorrectly formatted."));
-
-            // Check the post variables and record errors
-            if (trim($_GET['api_user_id']) != '')
-                if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['api_user_id'])) == 1)
-                    $account = str_replace("'","",str_replace(" ","",trim(urldecode($_GET['api_user_id']))));
-                else
-                    $errors['account_format'][0] = 1;
-            else
-                $errors['account_empty'][0] = 1;
-
-
-            // CHECK ERRORS
-            $errorCheck = false;
-            foreach ($errors as $field => $error) {
-                if ($error[0] == 1) {
-                    $errorCheck = true;
-                    break;
-                }
-            }
-
-
-            // SET DEFAULT ACCOUNT
-            if ( $errorCheck === false )
-            {
-                update_option( "Zotpress_DefaultAccount", $account );
-                $xml .= "<result success='true' account='".$account."' />\n";
-            }
-		}
-
-
-
-		/*
-
-		   SET STYLE DEFAULT
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "default_style" )
-		{
-			$errors = array("style_empty"=>array(0,"<strong>Style</strong> was left blank."),
-							"style_format"=>array(0,"<strong>Style</strong> was incorrectly formatted."));
-
-            // Check the post variables and record errors
-            if (trim($_GET['style']) != '')
-                if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['style'])) == 1)
-                    $style = str_replace("'","",str_replace(" ","",trim(urldecode($_GET['style']))));
-                else
-                    $errors['style_format'][0] = 1;
-            else
-                $errors['style_empty'][0] = 1;
-
-
-            // CHECK ERRORS
-            $errorCheck = false;
-            foreach ($errors as $field => $error) {
-                if ($error[0] == 1) {
-                    $errorCheck = true;
-                    break;
-                }
-            }
-
-
-            // SET DEFAULT ACCOUNT
-            if ( $errorCheck === false )
-            {
-                // Update style list
-                if (strpos(get_option("Zotpress_StyleList"), $style) === false)
-                    update_option( "Zotpress_StyleList", get_option("Zotpress_StyleList") . ", " . $style);
-
-                // Update default style
+		if (isset($_GET['action_type']) && $_GET['action_type'] == "add_account") {
+      // Set up error array
+      $errors =
+   				array(
+   					"api_user_id_blank"=>array(0,"<strong>User ID</strong> was left blank."),
+   					"api_user_id_format"=>array(0,"<strong>User ID</strong> was formatted incorrectly."),
+   					"public_key_blank"=>array(0,"<strong>Public Key</strong> was left blank."),
+   					"public_key_format"=>array(0,"<strong>Public Key</strong> was formatted incorrectly."),
+   					"nickname_format"=>array(0,"<strong>Nickname</strong> was formatted incorrectly.")
+   				);
+      // Check the post variables and record errors
+      // ACCOUNT TYPE
+      if ($_GET['account_type'] != "")
+   				$account_type = $_GET['account_type'] == "groups" ? "groups" : "users";
+   			else
+   				$account_type = "users";
+      // API USER ID
+      if ($_GET['api_user_id'] != "")
+   				if (preg_match("/^\\d+\$/", $_GET['api_user_id']) == 1)
+   					$api_user_id = htmlentities($_GET['api_user_id']);
+   				else
+   					$errors['api_user_id_format'][0] = 1;
+   			else
+   				$errors['api_user_id_blank'][0] = 1;
+      // PUBLIC KEY
+      $public_key = false;
+      if ($_GET['public_key'] != "")
+   				if (preg_match("/^[0-9a-zA-Z]+$/", $_GET['public_key']) == 1) {
+           $public_key = htmlentities(trim($_GET['public_key']));
+       } elseif ($account_type == "users") {
+           $errors['public_key_format'][0] = 1;
+       } elseif ($account_type == "users") {
+           $errors['public_key_blank'][0] = 1;
+       }
+      // NICKNAME
+      $nickname = false;
+      if (isset($_GET['nickname']) && trim($_GET['nickname']) != '')
+   				if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['nickname'])) == 1)
+   					$nickname = str_replace("'", "", str_replace(" ", "", trim(urldecode($_GET['nickname']))));
+   				else
+   					$errors['nickname_format'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+   				if ($error[0] == 1) {
+   					$errorCheck = true;
+   					break;
+   				}
+   			}
+      // ADD ACCOUNT
+      if ($errorCheck == false)
+   			{
+   				$query = "INSERT INTO ".$wpdb->prefix."zotpress (account_type, api_user_id, public_key";
+   				if ($nickname) $query .= ", nickname";
+   				$query .= ") ";
+   				$query .= "VALUES ('$account_type', '$api_user_id', '$public_key'";
+   				if ($nickname) $query .= ", '$nickname'";
+   				$query .= ")";
+   
+   				// Insert new list item into the list:
+   				$wpdb->query($query);
+   
+   				// Display success XML
+   				$xml .= "<result success='true' api_user_id='".$api_user_id."' public_key='".$public_key."' />\n";
+   			}
+   
+   
+   			// DISPLAY ERRORS
+   
+   			else
+   			{
+   				$xml .= "<result success='false' />\n";
+   				$xml .= "<citation>\n";
+   				$xml .= "<errors>\n";
+   				foreach ($errors as $field => $error)
+   					if ($error[0] == 1)
+   						$xml .= $error[1]."\n";
+   				$xml .= "</errors>\n";
+   				$xml .= "</citation>\n";
+   			}
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "delete_account") {
+      if (preg_match("/^\\d+\$/", $_GET['api_user_id']))
+   			{
+   				$api_user_id = $_GET['api_user_id'];
+   
+   				// Delete account and items
+   				$wpdb->query("DELETE FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$api_user_id."'");
+   				zp_clear_cache_for_user ($wpdb, $api_user_id);
+   
+   				// Check if default account
+   				if ( get_option("Zotpress_DefaultAccount") && get_option("Zotpress_DefaultAccount") == $api_user_id )
+   					delete_option( "Zotpress_DefaultAccount" );
+   
+   				$total_accounts = $wpdb->get_var( "SELECT COUNT(*) FROM ".$wpdb->prefix."zotpress;" );
+   
+   				// Display success XML
+   				$xml .= "<result success='true' total_accounts='".$total_accounts."' />\n";
+   				$xml .= "<account id='".$api_user_id."' type='delete' />\n";
+   
+   				$wpdb->flush();
+   				unset($api_user_id);
+   			}
+   			else // die
+   			{
+   				exit();
+   			}
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "clear_cache") {
+      if (preg_match("/^\\d+\$/", $_GET['api_user_id']))
+   			{
+   				$api_user_id = $_GET['api_user_id'];
+   
+   				// Clear the cache
+   				zp_clear_cache_for_user ($wpdb, $api_user_id);
+   
+   				// Display success XML
+   				$xml .= "<result success='true' cache_cleared='true' />\n";
+   				$xml .= "<account id='".$api_user_id."' type='cache' />\n";
+   
+   				$wpdb->flush();
+   				unset($api_user_id);
+   			}
+   			else // die
+   			{
+   				exit();
+   			}
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "default_account") {
+      $errors = array("account_empty"=>array(0,"<strong>Account</strong> was left blank."),
+   							"account_format"=>array(0,"<strong>Account</strong> was incorrectly formatted."));
+      // Check the post variables and record errors
+      if (trim($_GET['api_user_id']) != '')
+          if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['api_user_id'])) == 1)
+              $account = str_replace("'","",str_replace(" ","",trim(urldecode($_GET['api_user_id']))));
+          else
+              $errors['account_format'][0] = 1;
+      else
+          $errors['account_empty'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+          if ($error[0] == 1) {
+              $errorCheck = true;
+              break;
+          }
+      }
+      // SET DEFAULT ACCOUNT
+      if ( $errorCheck === false )
+      {
+          update_option( "Zotpress_DefaultAccount", $account );
+          $xml .= "<result success='true' account='".$account."' />\n";
+      }
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "default_style") {
+      $errors = array("style_empty"=>array(0,"<strong>Style</strong> was left blank."),
+   							"style_format"=>array(0,"<strong>Style</strong> was incorrectly formatted."));
+      // Check the post variables and record errors
+      if (trim($_GET['style']) != '')
+          if (preg_match('/^[\'0-9a-zA-Z -_]+$/', stripslashes($_GET['style'])) == 1)
+              $style = str_replace("'","",str_replace(" ","",trim(urldecode($_GET['style']))));
+          else
+              $errors['style_format'][0] = 1;
+      else
+          $errors['style_empty'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+          if ($error[0] == 1) {
+              $errorCheck = true;
+              break;
+          }
+      }
+      // SET DEFAULT ACCOUNT
+      if ( $errorCheck === false )
+      {
+          // Update style list
+          if (strpos(get_option("Zotpress_StyleList"), $style) === false)
+              update_option( "Zotpress_StyleList", get_option("Zotpress_StyleList") . ", " . $style);
+
+          // Update default style
 				update_option("Zotpress_DefaultStyle", $style);
 				$xml .= "<result success='true' style='".$style."' />\n";
-            }
-		}
+      }
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "ref_widget_cpt") {
+      $errors = array("cpt_empty"=>array(0,"<strong>Content Type</strong> was left blank."),
+   							"cpt_format"=>array(0,"<strong>Content Type</strong> was incorrectly formatted."));
+      // Check the post variables and record errors
+      if (trim($_GET['cpt']) != '')
+          if (preg_match('/^[\'0-9a-zA-Z -_,]+$/', stripslashes($_GET['cpt'])) == 1)
+              $cpt = trim($_GET['cpt']);
+          else
+              $errors['cpt_format'][0] = 1;
+      else
+          $errors['cpt_empty'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+          if ($error[0] == 1) {
+              $errorCheck = true;
+              break;
+          }
+      }
+      // SET DEFAULT ACCOUNT
+      if ( $errorCheck === false )
+      {
+          update_option("Zotpress_DefaultCPT", $cpt);
+          $xml .= "<result success='true' cpt='".$cpt."' />\n";
+      }
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "reset") {
+      $errors = array("reset_empty"=>array(0,"<strong>Reset</strong> was left blank."));
+      // Check the post variables and record errors
+      if (trim($_GET['reset']) == 'true')
+          $reset = $_GET['reset'];
+      else
+          $errors['reset_empty'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+          if ($error[0] == 1) {
+              $errorCheck = true;
+              break;
+          }
+      }
+      if ( $errorCheck === false )
+      {
+          global $wpdb;
+          global $current_user;
 
-
-
-		/*
-
-		   SET REFERENCE WIDGET FOR CPT
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "ref_widget_cpt" )
-		{
-			$errors = array("cpt_empty"=>array(0,"<strong>Content Type</strong> was left blank."),
-							"cpt_format"=>array(0,"<strong>Content Type</strong> was incorrectly formatted."));
-
-            // Check the post variables and record errors
-            if (trim($_GET['cpt']) != '')
-                if (preg_match('/^[\'0-9a-zA-Z -_,]+$/', stripslashes($_GET['cpt'])) == 1)
-                    $cpt = trim($_GET['cpt']);
-                else
-                    $errors['cpt_format'][0] = 1;
-            else
-                $errors['cpt_empty'][0] = 1;
-
-
-            // CHECK ERRORS
-            $errorCheck = false;
-            foreach ($errors as $field => $error) {
-                if ($error[0] == 1) {
-                    $errorCheck = true;
-                    break;
-                }
-            }
-
-
-            // SET DEFAULT ACCOUNT
-            if ( $errorCheck === false )
-            {
-                update_option("Zotpress_DefaultCPT", $cpt);
-                $xml .= "<result success='true' cpt='".$cpt."' />\n";
-            }
-		}
-
-
-
-		/*
-
-		   RESET ZOTPRESS
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "reset" )
-		{
-			$errors = array("reset_empty"=>array(0,"<strong>Reset</strong> was left blank."));
-
-            // Check the post variables and record errors
-            if (trim($_GET['reset']) == 'true')
-                $reset = $_GET['reset'];
-            else
-                $errors['reset_empty'][0] = 1;
-
-
-            // CHECK ERRORS
-            $errorCheck = false;
-            foreach ($errors as $field => $error) {
-                if ($error[0] == 1) {
-                    $errorCheck = true;
-                    break;
-                }
-            }
-
-
-            if ( $errorCheck === false )
-            {
-                global $wpdb;
-                global $current_user;
-
-                // Drop all tables except accounts/main
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_oauth;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroItems;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroCollections;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroTags;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroRelItemColl;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroRelItemTags;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_cache ;");
-                $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroItemImages ;");
+          // Drop all tables except accounts/main
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_oauth;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroItems;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroCollections;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroTags;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroRelItemColl;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroRelItemTags;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_cache ;");
+          $wpdb->query("DROP TABLE IF EXISTS ".$wpdb->prefix."zotpress_zoteroItemImages ;");
 
 		        delete_option( 'Zotpress_cache_version' );
 		        delete_option( 'Zotpress_DefaultCPT' );
-                delete_option( 'Zotpress_DefaultAccount' );
-                delete_option( 'Zotpress_DefaultEditor' );
-                delete_option( 'Zotpress_DefaultStyle' );
-                delete_option( 'Zotpress_StyleList' );
-                delete_option( 'Zotpress_update_version' );
-                delete_option( 'Zotpress_main_db_version' );
-                delete_option( 'Zotpress_oauth_db_version' );
-                delete_option( 'Zotpress_zoteroItems_db_version' );
-                delete_option( 'Zotpress_zoteroCollections_db_version' );
-                delete_option( 'Zotpress_zoteroTags_db_version' );
-                delete_option( 'Zotpress_zoteroRelItemColl_db_version' );
-                delete_option( 'Zotpress_zoteroRelItemTags_db_version' );
+          delete_option( 'Zotpress_DefaultAccount' );
+          delete_option( 'Zotpress_DefaultEditor' );
+          delete_option( 'Zotpress_DefaultStyle' );
+          delete_option( 'Zotpress_StyleList' );
+          delete_option( 'Zotpress_update_version' );
+          delete_option( 'Zotpress_main_db_version' );
+          delete_option( 'Zotpress_oauth_db_version' );
+          delete_option( 'Zotpress_zoteroItems_db_version' );
+          delete_option( 'Zotpress_zoteroCollections_db_version' );
+          delete_option( 'Zotpress_zoteroTags_db_version' );
+          delete_option( 'Zotpress_zoteroRelItemColl_db_version' );
+          delete_option( 'Zotpress_zoteroRelItemTags_db_version' );
 				delete_option( 'Zotpress_zoteroItemImages_db_version' );
 				delete_option( 'Zotpress_update_notice_dismissed' );
 				delete_option( 'Zotpress_zoteroItemImages_db_version' );
 
-                delete_user_meta( $current_user->ID, 'zotpress_5_2_ignore_notice' );
-                delete_user_meta( $current_user->ID, 'zotpress_survey_notice_ignore' );
+          delete_user_meta( $current_user->ID, 'zotpress_5_2_ignore_notice' );
+          delete_user_meta( $current_user->ID, 'zotpress_survey_notice_ignore' );
 
-                $xml .= "<result success='true' reset='complete' />\n";
-            }
-		}
-
-
-
-		/*
-			ADD OR UPDATE IMAGE
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "add_image" )
-		{
-			// Set up error array
-			$errors = array(
-				"item_key_blank"=>array(0,"<strong>Entry ID</strong> was left blank or formatted incorrectly."),
-				"image_id_blank"=>array(0,"<strong>Image ID</strong> was left blank or formatted incorrectly."),
-				"api_user_id_blank"=>array(0,"<strong>API User ID</strong> was left blank or formatted incorrectly.")
-			);
-
-
-			// BASIC VARS
-			$api_user_id = false;
-			if (preg_match("/^[0-9]+$/", $_GET['api_user_id']))
-				$api_user_id = htmlentities(trim($_GET['api_user_id']));
-			else
-				$errors['api_user_id_blank'][0] = 1;
-
-			$item_key = false;
-			if (preg_match("/^[a-zA-Z0-9]+$/", $_GET['item_key']))
-				$item_key = htmlentities(trim($_GET['item_key']));
-			else
-				$errors['item_key_blank'][0] = 1;
-
-			$image_id = false;
-			if (preg_match("/^[0-9]+$/", $_GET['image_id']))
-				$image_id = htmlentities(trim($_GET['image_id']));
-			else
-				$errors['image_id_blank'][0] = 1;
-
-
-			// CHECK ERRORS
-			$errorCheck = false;
-			foreach ($errors as $field => $error) {
-				if ($error[0] == 1) {
-					$errorCheck = true;
-					break;
-				}
-			}
-
-
-			// SET FEATURED IMAGE
-
-			if ($errorCheck == false)
-			{
-				$wpdb->query(
-					$wpdb->prepare(
-						"
+          $xml .= "<result success='true' reset='complete' />\n";
+      }
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "add_image") {
+      // Set up error array
+      $errors = array(
+   				"item_key_blank"=>array(0,"<strong>Entry ID</strong> was left blank or formatted incorrectly."),
+   				"image_id_blank"=>array(0,"<strong>Image ID</strong> was left blank or formatted incorrectly."),
+   				"api_user_id_blank"=>array(0,"<strong>API User ID</strong> was left blank or formatted incorrectly.")
+   			);
+      // BASIC VARS
+      $api_user_id = false;
+      if (preg_match("/^\\d+\$/", $_GET['api_user_id']))
+   				$api_user_id = htmlentities(trim($_GET['api_user_id']));
+   			else
+   				$errors['api_user_id_blank'][0] = 1;
+      $item_key = false;
+      if (preg_match("/^[a-zA-Z0-9]+$/", $_GET['item_key']))
+   				$item_key = htmlentities(trim($_GET['item_key']));
+   			else
+   				$errors['item_key_blank'][0] = 1;
+      $image_id = false;
+      if (preg_match("/^\\d+\$/", $_GET['image_id']))
+   				$image_id = htmlentities(trim($_GET['image_id']));
+   			else
+   				$errors['image_id_blank'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+   				if ($error[0] == 1) {
+   					$errorCheck = true;
+   					break;
+   				}
+   			}
+      // SET FEATURED IMAGE
+      if ($errorCheck == false)
+   			{
+   				$wpdb->query(
+   					$wpdb->prepare(
+   						"
 						INSERT INTO ".$wpdb->prefix."zotpress_zoteroItemImages (api_user_id, item_key, image)
 						VALUES (%s, %s, %s)
 						ON DUPLICATE KEY UPDATE image=%s
 						",
-						$api_user_id, $item_key, $image_id, $image_id
-					)
-				);
-
-				$xml .= "<result success='true' citation_id='".$item_key."' />\n";
-			}
-
-
-			// DISPLAY ERRORS
-
-			else
-			{
-				$xml .= "<result success='false' />\n";
-				$xml .= "<citation>\n";
-				$xml .= "<errors>\n";
-				foreach ($errors as $field => $error)
-					if ($error[0] == 1)
-						$xml .= $error[1]."\n";
-				$xml .= "</errors>\n";
-				$xml .= "</citation>\n";
-			}
-		}
-
-
-
-		/*
-		   REMOVE IMAGE
-
-		*/
-
-		else if ( isset($_GET['action_type']) && $_GET['action_type'] == "remove_image" )
-		{
-			// Set up error array
-			$errors = array(
-					"item_key_blank"=>array(0,"<strong>Item Key</strong> was left blank or formatted incorrectly."),
-					"api_user_id_blank"=>array(0,"<strong>API User ID</strong> was left blank or formatted incorrectly.")
-				);
-
-
-			// BASIC VARS
-			$item_key = false;
-			if (preg_match("/^[A-Z0-9]+$/", $_GET['item_key']))
-				$item_key = htmlentities(trim($_GET['item_key']));
-			else
-				$errors['item_key_blank'][0] = 1;
-
-			$api_user_id = false;
-			if (preg_match("/^[A-Z0-9]+$/", $_GET['api_user_id']))
-				$api_user_id = htmlentities(trim($_GET['api_user_id']));
-			else
-				$errors['api_user_id_blank'][0] = 1;
-
-
-			// CHECK ERRORS
-			$errorCheck = false;
-			foreach ($errors as $field => $error) {
-				if ($error[0] == 1) {
-					$errorCheck = true;
-					break;
-				}
-			}
-
-
-			// REMOVE FEATURED IMAGE
-
-			if ($errorCheck == false)
-			{
-				$wpdb->query(
-					$wpdb->prepare(
-						"
+   						$api_user_id, $item_key, $image_id, $image_id
+   					)
+   				);
+   
+   				$xml .= "<result success='true' citation_id='".$item_key."' />\n";
+   			}
+   
+   
+   			// DISPLAY ERRORS
+   
+   			else
+   			{
+   				$xml .= "<result success='false' />\n";
+   				$xml .= "<citation>\n";
+   				$xml .= "<errors>\n";
+   				foreach ($errors as $field => $error)
+   					if ($error[0] == 1)
+   						$xml .= $error[1]."\n";
+   				$xml .= "</errors>\n";
+   				$xml .= "</citation>\n";
+   			}
+  } elseif (isset($_GET['action_type']) && $_GET['action_type'] == "remove_image") {
+      // Set up error array
+      $errors = array(
+   					"item_key_blank"=>array(0,"<strong>Item Key</strong> was left blank or formatted incorrectly."),
+   					"api_user_id_blank"=>array(0,"<strong>API User ID</strong> was left blank or formatted incorrectly.")
+   				);
+      // BASIC VARS
+      $item_key = false;
+      if (preg_match("/^[A-Z0-9]+$/", $_GET['item_key']))
+   				$item_key = htmlentities(trim($_GET['item_key']));
+   			else
+   				$errors['item_key_blank'][0] = 1;
+      $api_user_id = false;
+      if (preg_match("/^[A-Z0-9]+$/", $_GET['api_user_id']))
+   				$api_user_id = htmlentities(trim($_GET['api_user_id']));
+   			else
+   				$errors['api_user_id_blank'][0] = 1;
+      // CHECK ERRORS
+      $errorCheck = false;
+      foreach ($errors as $field => $error) {
+   				if ($error[0] == 1) {
+   					$errorCheck = true;
+   					break;
+   				}
+   			}
+      // REMOVE FEATURED IMAGE
+      if ($errorCheck == false)
+   			{
+   				$wpdb->query(
+   					$wpdb->prepare(
+   						"
 						DELETE FROM ".$wpdb->prefix."zotpress_zoteroItemImages
 						WHERE item_key=%s AND api_user_id=%s
 						",
-						$item_key, $api_user_id
-					)
-				);
-
-				$xml .= "<result success='true' item_key='".$item_key."' />\n";
-			}
-
-			// DISPLAY ERRORS
-
-			else
-			{
-				$xml .= "<result success='false' />\n";
-				$xml .= "<citation>\n";
-				$xml .= "<errors>\n";
-				foreach ($errors as $field => $error)
-					if ($error[0] == 1)
-						$xml .= $error[1]."\n";
-				$xml .= "</errors>\n";
-				$xml .= "</citation>\n";
-			}
-		}
+   						$item_key, $api_user_id
+   					)
+   				);
+   
+   				$xml .= "<result success='true' item_key='".$item_key."' />\n";
+   			}
+   
+   			// DISPLAY ERRORS
+   
+   			else
+   			{
+   				$xml .= "<result success='false' />\n";
+   				$xml .= "<citation>\n";
+   				$xml .= "<errors>\n";
+   				foreach ($errors as $field => $error)
+   					if ($error[0] == 1)
+   						$xml .= $error[1]."\n";
+   				$xml .= "</errors>\n";
+   				$xml .= "</citation>\n";
+   			}
+  }
 
 
 		// DISPLAY XML

--- a/lib/admin/admin.setup.php
+++ b/lib/admin/admin.setup.php
@@ -1,36 +1,44 @@
-<?php if (!isset( $_GET['setupstep'] )) { ?>
+<?php if (!isset( $_GET['setupstep'] )) {
+    ?>
 
     <div id="zp-Setup">
 
         <div id="zp-Zotpress-Navigation">
 
             <div id="zp-Icon">
-                <img src="<?php echo ZOTPRESS_PLUGIN_URL; ?>/images/icon-64x64.png" title="Zotero + WordPress = Zotpress">
+                <img src="<?php 
+    echo ZOTPRESS_PLUGIN_URL;
+    ?>/images/icon-64x64.png" title="Zotero + WordPress = Zotpress">
             </div>
 
             <div class="nav">
-                <div id="step-1" class="nav-item nav-tab-active"><strong>1.</strong> <?php _e('Validate Account','zotpress'); ?></div>
-                <div id="step-2" class="nav-item"><strong>2.</strong> <?php _e('Default Options','zotpress'); ?></div>
+                <div id="step-1" class="nav-item nav-tab-active"><strong>1.</strong> <?php 
+    _e('Validate Account','zotpress');
+    ?></div>
+                <div id="step-2" class="nav-item"><strong>2.</strong> <?php 
+    _e('Default Options','zotpress');
+    ?></div>
             </div>
 
         </div><!-- #zp-Zotpress-Navigation -->
 
         <div id="zp-Setup-Step">
 
-            <?php
-
-            $zp_check_curl = intval( function_exists('curl_version') );
-            $zp_check_streams = intval( function_exists('stream_get_contents') );
-            $zp_check_fsock = intval( function_exists('fsockopen') );
-
-            if ( ($zp_check_curl + $zp_check_streams + $zp_check_fsock) <= 1 ) { ?>
+            <?php 
+    $zp_check_curl = (int) function_exists('curl_version');
+    $zp_check_streams = (int) function_exists('stream_get_contents');
+    $zp_check_fsock = (int) function_exists('fsockopen');
+    if ( ($zp_check_curl + $zp_check_streams + $zp_check_fsock) <= 1 ) { ?>
             <div id="zp-Setup-Check" class="error">
-                <p><strong><?php _e('Warning','zotpress'); ?>!</strong> <?php _e('Zotpress requires at least one of the following to work: cURL, fopen with Streams (PHP 5), or fsockopen. You will not be able to use Zotpress until your administrator or tech support has set up one of these options. cURL is recommended.','zotpress'); ?></p>
-            </div>
-            <?php } ?>
+        <p><strong><?php _e('Warning','zotpress'); ?>!</strong> <?php _e('Zotpress requires at least one of the following to work: cURL, fopen with Streams (PHP 5), or fsockopen. You will not be able to use Zotpress until your administrator or tech support has set up one of these options. cURL is recommended.','zotpress'); ?></p>
+    </div>
+    <?php }
+    ?>
 
             <div id="zp-AddAccount-Form" class="visible">
-                <?php include('admin.accounts.addform.php'); ?>
+                <?php 
+    include(__DIR__ . '/admin.accounts.addform.php');
+    ?>
             </div>
 
         </div>
@@ -39,35 +47,50 @@
 
 
 
-<?php } else if (isset($_GET['setupstep']) && $_GET['setupstep'] == "two") { ?>
+<?php 
+} elseif (isset($_GET['setupstep']) && $_GET['setupstep'] == "two") {
+    ?>
 
     <div id="zp-Setup">
 
         <div id="zp-Zotpress-Navigation">
 
             <div id="zp-Icon">
-                <img src="<?php echo ZOTPRESS_PLUGIN_URL; ?>/images/icon-64x64.png" title="Zotero + WordPress = Zotpress">
+                <img src="<?php 
+    echo ZOTPRESS_PLUGIN_URL;
+    ?>/images/icon-64x64.png" title="Zotero + WordPress = Zotpress">
             </div>
 
             <div class="nav">
-                <div id="step-1" class="nav-item"><strong>1.</strong> <?php _e('Validate Account','zotpress'); ?></div>
-                <div id="step-2" class="nav-item nav-tab-active"><strong>2.</strong> <?php _e('Default Options','zotpress'); ?></div>
+                <div id="step-1" class="nav-item"><strong>1.</strong> <?php 
+    _e('Validate Account','zotpress');
+    ?></div>
+                <div id="step-2" class="nav-item nav-tab-active"><strong>2.</strong> <?php 
+    _e('Default Options','zotpress');
+    ?></div>
             </div>
 
         </div><!-- #zp-Zotpress-Navigation -->
 
         <div id="zp-Setup-Step">
 
-            <h3><?php _e('Set Default Options','zotpress'); ?></h3>
+            <h3><?php 
+    _e('Set Default Options','zotpress');
+    ?></h3>
 
-            <?php include("admin.options.form.php"); ?>
+            <?php 
+    include(__DIR__ . "/admin.options.form.php");
+    ?>
 
             <div id="zp-Zotpress-Setup-Buttons" class="proceed">
-                <input type="button" id="zp-Zotpress-Setup-Options-Complete" class="button-primary" value="<?php _e('Finish','zotpress'); ?>">
+                <input type="button" id="zp-Zotpress-Setup-Options-Complete" class="button-primary" value="<?php 
+    _e('Finish','zotpress');
+    ?>">
             </div>
 
         </div>
 
     </div>
 
-<?php } ?>
+<?php 
+} ?>

--- a/lib/request/request.cite.php
+++ b/lib/request/request.cite.php
@@ -6,8 +6,8 @@
 	define('WP_USE_THEMES', false);
 
 	// Include Request Functionality
-	require('request.class.php');
-	require('request.functions.php');
+	require(__DIR__ . '/request.class.php');
+	require(__DIR__ . '/request.functions.php');
 
 	// Content prep
 	$zp_xml = false;

--- a/lib/request/request.class.php
+++ b/lib/request/request.class.php
@@ -16,7 +16,7 @@ if ( ! class_exists('ZotpressRequest') )
 {
     class ZotpressRequest
     {
-        var $update = false,
+        public $update = false,
             $request_error = false,
             $checkEveryMin = 10, // minutes
             $api_user_id,
@@ -215,7 +215,7 @@ if ( ! class_exists('ZotpressRequest') )
             // Or, if cached version exists, check to see if it's out of date,
             // and return whichever is newer (and cache the newest).
             if ( count($zp_results) == 0
-                    || ( isset($zp_results[0]->retrieved)
+                    || ( property_exists($zp_results[0], 'retrieved') && $zp_results[0]->retrieved !== null
                             && $this->checkTime($zp_results[0]->retrieved) ) )
             {
                 $headers_arr = array ( "Zotero-API-Version" => "3" );
@@ -239,33 +239,25 @@ if ( ! class_exists('ZotpressRequest') )
                                 && $response["response"]["code"] != "304" ) )
                 {
                     // Deal with errors
-                    if ( is_wp_error($response)
-                            || ! isset($response['body']) )
-                    {
+                    if (is_wp_error($response)
+                            || ! isset($response['body'])) {
                         $this->request_error = $response->get_error_message();
-
                         if ( $response->get_error_code() == "http_request_failed" )
                         {
                             // Try again with less restrictions
                             add_filter('https_ssl_verify', '__return_false');
                             $response = wp_remote_get( $url, array( 'headers' => array("Zotero-API-Version" => "2") ) );
 
-                            if ( is_wp_error($response) || ! isset($response['body']) )
-                            {
+                            if (is_wp_error($response) || ! isset($response['body'])) {
                                 $this->request_error = $response->get_error_message();
-                            }
-                            else if ( $response == "An error occurred" || ( isset($response['body']) && $response['body'] == "An error occurred") )
-                            {
+                            } elseif ($response == "An error occurred" || ( isset($response['body']) && $response['body'] == "An error occurred")) {
                                 $this->request_error = "WordPress was unable to import from Zotero. This is likely caused by an incorrect citation style name. For example, 'mla' is now 'modern-language-association'. Use the name found in the style's URL at the Zotero Style Repository.";
-                            }
-                            else // no errors this time
+                            } else // no errors this time
                             {
                                 $this->request_error = false;
                             }
                         }
-                    }
-                    else if ( $response == "An error occurred" || ( isset($response['body']) && $response['body'] == "An error occurred") )
-                    {
+                    } elseif ($response == "An error occurred" || ( isset($response['body']) && $response['body'] == "An error occurred")) {
                         $this->request_error = "WordPress was unable to import from Zotero. This is likely caused by an incorrect citation style name. For example, 'mla' is now 'modern-language-association'. Use the name found in the style's URL at the Zotero Style Repository.";
                     }
 
@@ -291,7 +283,7 @@ if ( ! class_exists('ZotpressRequest') )
                             $tags = array(); // empty for now; by item key later
 
                             // If not array, turn into one for simplicity
-                            if ( is_array($data) === false ) $data = array($data);
+                            if ( !is_array($data) ) $data = array($data);
 
                             // Remove unncessary details
                             // REVIEW: Does this account for all unused metadata? Depends on item type ...

--- a/lib/request/request.dl.php
+++ b/lib/request/request.dl.php
@@ -6,8 +6,8 @@
 	define('WP_USE_THEMES', false);
 
 	// Include Request Functionality
-	require('request.class.php');
-	require('request.functions.php');
+	require(__DIR__ . '/request.class.php');
+	require(__DIR__ . '/request.functions.php');
 
 	// Content prep
 	$zp_data_xml = false;

--- a/lib/request/request.functions.php
+++ b/lib/request/request.functions.php
@@ -12,8 +12,7 @@
     {
         function zp_db_prep ($input)
         {
-            $input =  str_replace("%", "%%", $input);
-            return ($input);
+            return (str_replace("%", "%%", $input));
         }
     }
 
@@ -40,11 +39,11 @@
     {
         function zp_get_api_user_id ($api_user_id_incoming=false)
         {
-            if (isset($_GET['api_user_id']) && preg_match("/^[0-9]+$/", $_GET['api_user_id']) == 1)
+            if (isset($_GET['api_user_id']) && preg_match("/^\\d+\$/", $_GET['api_user_id']) == 1) {
                 $api_user_id = htmlentities($_GET['api_user_id']);
-            else if ($api_user_id_incoming !== false)
+            } elseif ($api_user_id_incoming !== false) {
                 $api_user_id = $api_user_id_incoming;
-            else
+            } else
                 $api_user_id = false;
 
             return $api_user_id;
@@ -94,63 +93,42 @@
     		$author = strtolower($author);
 
     		// Accounts for last names with: de, van, el, seif
-    		if ( strpos( strtolower($author), "van " ) !== false )
-    		{
-    			$author = explode( "van ", $author );
-    			$author[1] = "van ".$author[1];
-    		}
-    		else if ( strpos( strtolower($author), "de " ) !== false )
-    		{
-    			$author = explode( "de ", $author );
-    			$author[1] = "de ".$author[1];
-    		}
-    		else if ( strpos( strtolower($author), "el " ) !== false )
-    		{
-    			$author = explode( "el ", $author );
-    			$author[1] = "el ".$author[1];
-    		}
-    		else if ( strpos( strtolower($author), "seif " ) !== false )
-    		{
-    			$author = explode( "seif ", $author );
-    			$author[1] = "seif ".$author[1];
-    		}
-    		else // Multipart names
-    		{
-    			// First and last names OR multiple last names
-    			if ( strpos( strtolower($author), " " ) !== false )
-    			{
-    				$author = explode( " ", $author );
-
-    				// Deal with multiple blanks
-                    // NOTE: Previously assumed multiple first/middle names
-                    // CHANGED: Check this possibility as well as multiple (7.3)
-                    // last names; so keep array of 1-3+ items
-    				// if ( count($author) > 2 )
-    				// {
-    				// 	$new_name = array();
-    				// 	foreach ( $author as $num => $author_name )
-    				// 	{
-    				// 		if ( $num == 0 ) $new_name[0] .= $author_name;
-    				// 		else if ( $num != count($author)-1 ) $new_name[0] .= " ". $author_name;
-    				// 		else if ( $num == count($author)-1 ) $new_name[1] .= $author_name;
-    				// 	}
-    				// 	$author = $new_name;
-    				// }
-    			}
-    			else // Multi-part last name with plus sign separator
-    			{
-                    // REVIEW: What if there's a first name(s)?
-                    if ( strpos( strtolower($author), "+" ) !== false )
-                    {
-                        // $author = explode( "+", $author );
-                        $author = array( str_replace( "+", " ", $author ) );
-                    }
-                    else // Just last name
-                    {
-                        $author = array( $author );
-                    }
-    			}
-    		}
+    		if (stripos( $author, "van " ) !== false) {
+          $author = explode( "van ", $author );
+          $author[1] = "van ".$author[1];
+      } elseif (stripos( $author, "de " ) !== false) {
+          $author = explode( "de ", $author );
+          $author[1] = "de ".$author[1];
+      } elseif (stripos( $author, "el " ) !== false) {
+          $author = explode( "el ", $author );
+          $author[1] = "el ".$author[1];
+      } elseif (stripos( $author, "seif " ) !== false) {
+          $author = explode( "seif ", $author );
+          $author[1] = "seif ".$author[1];
+      } elseif (stripos( $author, " " ) !== false) {
+          $author = explode( " ", $author );
+          // Deal with multiple blanks
+          // NOTE: Previously assumed multiple first/middle names
+          // CHANGED: Check this possibility as well as multiple (7.3)
+          // last names; so keep array of 1-3+ items
+          // if ( count($author) > 2 )
+          // {
+          // 	$new_name = array();
+          // 	foreach ( $author as $num => $author_name )
+          // 	{
+          // 		if ( $num == 0 ) $new_name[0] .= $author_name;
+          // 		else if ( $num != count($author)-1 ) $new_name[0] .= " ". $author_name;
+          // 		else if ( $num == count($author)-1 ) $new_name[1] .= $author_name;
+          // 	}
+          // 	$author = $new_name;
+          // }
+      } elseif (stripos( $author, "+" ) !== false) {
+          // $author = explode( "+", $author );
+          $author = array( str_replace( "+", " ", $author ) );
+      } else // Just last name
+      {
+          $author = array( $author );
+      }
 
     		// Deal with blank firstname
     		if ( $author[0] == "" )
@@ -169,43 +147,35 @@
                 // NOTE: Assumes last name only
     			if ( count($author) == 1 )
     			{
-    				if ( ( isset($creator->lastName)
-                            && strtolower($creator->lastName) == $author[0] )
-    						|| ( isset($creator->name)
-                                    && strtolower($creator->name) == $author[0] ) )
+    				if ( ( property_exists($creator, 'lastName') && $creator->lastName !== null
+                            && strtolower($creator->lastName) === $author[0] )
+    						|| ( property_exists($creator, 'name') && $creator->name !== null
+                                    && strtolower($creator->name) === $author[0] ) )
     					$author_continue = true;
     			}
                 // NOTE: Assumes first and last names OR two last names
     			elseif ( count($author) == 2 )
     			{
-    				if ( ( isset($creator->firstName)
-						&& ( strtolower($creator->firstName) == $author[0]
-						&& strtolower($creator->lastName) == $author[1] )
+    				if ( ( property_exists($creator, 'firstName') && $creator->firstName !== null
+						&& ( strtolower($creator->firstName) === $author[0]
+						&& strtolower($creator->lastName) === $author[1] )
                        )
-                       || ( strtolower($creator->lastName) == $author[0]." ".$author[1] )
-                       || ( isset($creator->name)
-                            && ( strtolower($creator->name) == implode(" ", $author) ) ) )
+                       || ( strtolower($creator->lastName) === $author[0]." ".$author[1] )
+                       || ( property_exists($creator, 'name') && $creator->name !== null
+                            && ( strtolower($creator->name) === implode(" ", $author) ) ) )
     					$author_continue = true;
-    			}
-                else {
-                    // NOTE: Assumes multiple first (inc. middle) OR multiple last
-                    // with at least one first name
-                    // CHANGED: Fix for multiple last names (7.3)
-                    if 	(
-                        // Two first names (or one middle) and last name
-                        ( isset($creator->firstName)
-							&& ( strtolower($creator->firstName) == ($author[0]." ".$author[1])
-			                     && strtolower($creator->lastName) == $author[2] ) )
-                        // One first name and two last names
-						|| ( isset($creator->firstName)
-                            && ( strtolower($creator->firstName) == $author[0]
-                                && strtolower($creator->lastName) == ($author[1]." ".$author[2]) ) )
-                        // All combined
-                        || ( isset($creator->name)
-                                && strtolower($creator->name) == implode(" ", $author) )
-                    )
-    					$author_continue = true;
-                }
+    			} elseif (( property_exists($creator, 'firstName') && $creator->firstName !== null
+							&& ( strtolower($creator->firstName) === $author[0]." ".$author[1]
+			                     && strtolower($creator->lastName) === $author[2] ) )
+       // One first name and two last names
+						|| ( property_exists($creator, 'firstName') && $creator->firstName !== null
+                      && ( strtolower($creator->firstName) === $author[0]
+                          && strtolower($creator->lastName) === $author[1]." ".$author[2] ) )
+       // All combined
+       || ( property_exists($creator, 'name') && $creator->name !== null
+               && strtolower($creator->name) === implode(" ", $author) )) {
+           $author_continue = true;
+       }
     		}
 
     		return $author_continue;

--- a/lib/shortcode/shortcode.class.lib.php
+++ b/lib/shortcode/shortcode.class.lib.php
@@ -122,16 +122,14 @@ class zotpressLib
 
 	public function setShowTags($showtags)
 	{
-		if ( $showtags == "yes" || $showtags == "true" || $showtags === true ) $showtags = true;
-		else $showtags = false;
+		$showtags = $showtags == "yes" || $showtags == "true" || $showtags === true;
 
 		$this->showtags = $showtags;
 	}
 
 	public function setShowImage($showimage)
 	{
-		if ( $showimage == "yes" || $showimage == "true" || $showimage === true ) $showimage = true;
-		else $showimage = false;
+		$showimage = $showimage == "yes" || $showimage == "true" || $showimage === true;
 
 		$this->showimage = $showimage;
 	}
@@ -202,7 +200,7 @@ class zotpressLib
 		if ( isset($_GET['page'])
 				&& $_GET['page'] == "Zotpress" // REVIEW: only include GET if admin?
 				&& isset($_GET['account_id'])
-				&& preg_match("/^[0-9]+$/", $_GET['account_id']) )
+				&& preg_match("/^\\d+\$/", $_GET['account_id']) )
 			$api_user_id = $wpdb->get_var("SELECT nickname FROM ".$wpdb->prefix."zotpress WHERE id='".$_GET['account_id']."'", OBJECT);
 		else
 			$api_user_id = $this->getAccount()->api_user_id;
@@ -211,21 +209,17 @@ class zotpressLib
 		// Collection ID
 		global $collection_id;
 
-		if ( isset($_GET['page'])
+		if (isset($_GET['page'])
 				&& $_GET['page'] == "Zotpress" // REVIEW: only include GET if admin?
 				&& isset($_GET['collection_id'])
-				&& preg_match("/^[0-9a-zA-Z]+$/", $_GET['collection_id']))
-			$collection_id = trim($_GET['collection_id']);
-
-		// REVIEW: Added to make subcollctions on admin work (7.3.1.2)
-		else if ( isset($_GET['page'])
+				&& preg_match("/^[0-9a-zA-Z]+$/", $_GET['collection_id'])) {
+      $collection_id = trim($_GET['collection_id']);
+  } elseif (isset($_GET['page'])
 				&& $_GET['page'] == "Zotpress" // REVIEW: only include GET if admin?
 				&& isset($_GET['subcollection_id'])
-				&& preg_match("/^[0-9a-zA-Z]+$/", $_GET['subcollection_id']))
-			$collection_id = trim($_GET['subcollection_id']);
-
-		// REVIEW: What happens here?
-		else
+				&& preg_match("/^[0-9a-zA-Z]+$/", $_GET['subcollection_id'])) {
+      $collection_id = trim($_GET['subcollection_id']);
+  } else
 			$collection_id = $this->collection; // from false
 
 
@@ -358,8 +352,11 @@ class zotpressLib
 						// if ( ! $tag_id && ! $collection_id ) $content .= "<option value='toplevel'>".__('Top Level','zotpress')."</option>";
 						// REVIEW: Uhhhh
 						if ( ! $tag_id && ! $collection_id )
-							if ( $this->toplevel == "toplevel" || $this->toplevel === false ) $content .= "<option value='blank' class='blank'>".__('Top Level','zotpress')."</option>";
-							else if ( $this->toplevel != "toplevel" ) $content .= "<option value='blank' class='blank'>".__('Default Collection','zotpress')."</option>";
+							if ($this->toplevel == "toplevel" || $this->toplevel === false) {
+           $content .= "<option value='blank' class='blank'>".__('Top Level','zotpress')."</option>";
+       } elseif ($this->toplevel != "toplevel") {
+           $content .= "<option value='blank' class='blank'>".__('Default Collection','zotpress')."</option>";
+       }
 	                    $content .= "</select>\n";
 	                    $content .= "</div>\n\n";
 	                $content .= '</div><!-- .zp-Browse-Collections -->';
@@ -394,8 +391,7 @@ class zotpressLib
 	                foreach ( $filters as $id => $filter )
 	                {
 	                    // Account for singular words
-	                    if ( $filter == "tags" ) $filter = "tag";
-	                    else $filter = "item";
+	                    $filter = $filter == "tags" ? "tag" : "item";
 
 	                    $content .= '<div class="zpSearchFilterContainer">';
 	                    $content .= '<input type="radio" name="zpSearchFilters" class="'.$filter.'" value="'.$filter.'"';
@@ -410,19 +406,19 @@ class zotpressLib
 
 
 	                // Min Length
-	                $minlength = 3; if ( $this->getMinLength() ) $minlength = intval($this->getMinLength());
+	                $minlength = 3; if ( $this->getMinLength() ) $minlength = (int) $this->getMinLength();
 	                $content .= '<input type="hidden" class="ZOTPRESS_AC_MINLENGTH" name="ZOTPRESS_AC_MINLENGTH" value="'.$minlength.'" />';
 
 	                // Max Results per Request
-	                $maxresults = 50; if ( $this->getMaxResults() ) $maxresults = intval($this->getMaxResults());
+	                $maxresults = 50; if ( $this->getMaxResults() ) $maxresults = (int) $this->getMaxResults();
 	                $content .= '<input type="hidden" class="ZOTPRESS_AC_MAXRESULTS" name="ZOTPRESS_AC_MAXRESULTS" value="'.$maxresults.'" />';
 
 	                // Max Per Page
-	                $maxperpage = 10; if ( $this->getMaxPerPage() ) $maxperpage = intval($this->getMaxPerPage());
+	                $maxperpage = 10; if ( $this->getMaxPerPage() ) $maxperpage = (int) $this->getMaxPerPage();
 	                $content .= '<input type="hidden" class="ZOTPRESS_AC_MAXPERPAGE" name="ZOTPRESS_AC_MAXPERPAGE" value="'.$maxperpage.'" />';
 
 	                // Max Pages
-	                $maxpages = intval($this->getMaxPages());
+	                $maxpages = (int) $this->getMaxPages();
 	                $content .= '<input type="hidden" class="ZOTPRESS_AC_MAXPAGES" name="ZOTPRESS_AC_MAXPAGES" value="'.$maxpages.'" />';
 
 	                // Downloadable, Citeable, Showimages
@@ -453,31 +449,24 @@ class zotpressLib
             $content .= ' loading">';
 
             // Display title on dropdown version
-            if ( $collection_id )
-            {
+            if ($collection_id) {
                 $content .= "<div class='zp-Collection-Title'>";
-                    $content .= "<span class='name'>";
-                    if ( $collection_name )
-                        $content .= $collection_name;
-                    else
-                        $content .= __('Collection items','zotpress').":";
-                    $content .= "</span>";
-                    if ( is_admin() )
-                        $content .= "<label for='item_key'>".__('Collection Key','zotpress').":</label><input type='text' name='item_key' class='item_key' value='".$collection_id."'>\n";
+                $content .= "<span class='name'>";
+                if ( $collection_name )
+                    $content .= $collection_name;
+                else
+                    $content .= __('Collection items','zotpress').":";
+                $content .= "</span>";
+                if ( is_admin() )
+                    $content .= "<label for='item_key'>".__('Collection Key','zotpress').":</label><input type='text' name='item_key' class='item_key' value='".$collection_id."'>\n";
                 $content .= "</div>\n";
-            }
-            else if ( $tag_id ) // Top Level
-            {
+            } elseif ($tag_id) {
+                // Top Level
                 $content .= "<div class='zp-Collection-Title'>".__('Viewing items tagged','zotpress')." \"<strong>".str_replace("+", " ", $tag_id)."</strong>\"</div>\n";
-            }
-            else
-            {
-				// REVIEW
-				if ( $this->toplevel == "toplevel" || $this->toplevel === false )
-					$content .= "<div class='zp-Collection-Title'>".__('Top Level Items','zotpress')."</div>\n";
-				else
-					$content .= "<div class='zp-Collection-Title'>".__('Default Collection Items','zotpress')."</div>\n";
-            }
+            } elseif ($this->toplevel == "toplevel" || $this->toplevel === false) {
+                $content .= "<div class='zp-Collection-Title'>".__('Top Level Items','zotpress')."</div>\n";
+            } else
+        					$content .= "<div class='zp-Collection-Title'>".__('Default Collection Items','zotpress')."</div>\n";
         }
 
         // Searchbar
@@ -503,9 +492,8 @@ class zotpressLib
         $content .= "\n";
 
         $content .= '</div><!-- .zp-Browse -->';
-        $content .= "\n\n";
 
-        return $content;
+        return $content . "\n\n";
 	}
 }
 

--- a/lib/shortcode/shortcode.functions.php
+++ b/lib/shortcode/shortcode.functions.php
@@ -32,9 +32,8 @@ function zp_clean_param( $param )
 
 	// Fix the String
 	$clean_param = htmlspecialchars( $param, ENT_QUOTES );
-	$clean_param = str_replace( $search, "", $clean_param );
 
-	return $clean_param;
+	return str_replace( $search, "", $clean_param );
 }
 
 
@@ -55,10 +54,7 @@ function zp_get_year( $date, $yesnd=false )
 	preg_match_all( '/(\d{4})/', $date, $matches );
 
 	if (is_null($matches[0][0]))
-		if ( $yesnd === true )
-			$date_return = "n.d.";
-		else
-			$date_return = "";
+		$date_return = $yesnd === true ? "n.d." : "";
 	else
 		$date_return = $matches[0][0];
 
@@ -80,35 +76,34 @@ function zp_get_year( $date, $yesnd=false )
 function subval_sort( $item_arr, $sortby, $order )
 {
 	// Format sort order
-	if ( strtolower($order) == "desc" ) $order = SORT_DESC; else $order = SORT_ASC;
+	$order = strtolower($order) == "desc" ? SORT_DESC : SORT_ASC;
 
 	// Author or date
-	if ( $sortby == "author" || $sortby == "date" )
-	{
-		foreach ($item_arr as $key => $val)
-		{
-			$author[$key] = $val["author"];
+	if ($sortby == "author" || $sortby == "date") {
+     foreach ($item_arr as $key => $val)
+   		{
+   			$author[$key] = $val["author"];
 
-			$zpdate = ""; if ( isset( $val["zpdate"] ) ) $zpdate = $val["zpdate"]; else $zpdate = $val["date"];
+   			$zpdate = ""; $zpdate = isset( $val["zpdate"] ) ? $val["zpdate"] : $val["date"];
 
-			$date[$key] = zp_date_format($zpdate);
-		}
-	}
-
-	// Title
-	else if ( $sortby == "title" )
-	{
-		foreach ($item_arr as $key => $val)
-		{
-			$title[$key] = $val["title"];
-			$author[$key] = $val["author"];
-		}
-	}
+   			$date[$key] = zp_date_format($zpdate);
+   		}
+ } elseif ($sortby == "title") {
+     foreach ($item_arr as $key => $val)
+   		{
+   			$title[$key] = $val["title"];
+   			$author[$key] = $val["author"];
+   		}
+ }
 
 	// NOTE: array_multisort seems to be ignoring second sort for date->author
-	if ( $sortby == "author" && isset($author) && is_array($author) ) array_multisort( $author, $order, $date, $order, $item_arr );
-	else if ( $sortby == "date" && isset($date) && is_array($date) ) array_multisort( $date, $order, $author, SORT_ASC, $item_arr );
-	else if ( $sortby == "title" && isset($title) && is_array($title) ) array_multisort( $title, $order, $author, $order, $item_arr );
+	if ($sortby == "author" && isset($author) && is_array($author)) {
+     array_multisort( $author, $order, $date, $order, $item_arr );
+ } elseif ($sortby == "date" && isset($date) && is_array($date)) {
+     array_multisort( $date, $order, $author, SORT_ASC, $item_arr );
+ } elseif ($sortby == "title" && isset($title) && is_array($title)) {
+     array_multisort( $title, $order, $author, $order, $item_arr );
+ }
 
 	return $item_arr;
 }
@@ -138,7 +133,7 @@ function zp_date_format ($date)
 
 
 	// Check if it's a mm-mm dash
-	if ( preg_match("/^[a-zA-Z]+[-][a-zA-Z]+[ ][0-9]+$/", $date ) == 1)
+	if ( preg_match("/^[a-zA-Z]+[-][a-zA-Z]+[ ]\\d+\$/", $date ) == 1)
 	{
 		$temp1 = preg_split( "/-|\//", $date );
 		$temp2 = preg_split( "[\s]", $temp1[1] );
@@ -147,122 +142,99 @@ function zp_date_format ($date)
 	}
 
 	// If it's already formatted with a dash or forward slash
-	if ( strpos( $date, "-" ) !== false || strpos( $date, "/" ) !== false )
-	{
-		// Break it up
-		$temp = preg_split( "/-|\//", $date );
-
-		// If year is last, switch it with first
-		if ( strlen( $temp[0] ) != 4 )
-		{
-			// Just month and year
-			if ( count( $temp ) == 2 )
-				$date_formatted = array(
-					"year" => $temp[1],
-					"month" => $temp[0],
-					"day" => false
-				);
-			// Assuming mm dd yyyy
-			else
-				$date_formatted = array(
-					"year" => $temp[2],
-					"month" => $temp[0],
-					"day" => $temp[1]
-				);
-		}
-		else // Year is first
-		{
-			if ( isset($temp[2]) ) // day is set
-			{
-				$date_formatted = array(
-					"year" => $temp[0],
-					"month" => $temp[1],
-					"day" => $temp[2]
-				);
-			}
-			else
-			{
-				$date_formatted = array(
-					"year" => $temp[0],
-					"month" => $temp[1],
-					"day" => false
-				);
-			}
-		}
-	}
-
-	// If it's already formatted in mmmm dd, yyyy form
-	else if ( strpos( $date, "," ) )
-	{
-		$date = trim( str_replace( ", ", ",", $date ) );
-		$temp = preg_split( "/,| /", $date );
-
-		// Convert month
-		$month = array_search( $temp[0], $list_month_long );
-		if ( !$month ) $month = array_search( $temp[0], $list_month_short );
-
-		$date_formatted = array(
-			"year" => $temp[2],
-			"month" => $month,
-			"day" => $temp[1]
-		);
-	}
-	// Check for full names
-	else
+	if (strpos( $date, "-" ) !== false || strpos( $date, "/" ) !== false) {
+     // Break it up
+     $temp = preg_split( "/-|\//", $date );
+     // If year is last, switch it with first
+     if (strlen( $temp[0] ) != 4) {
+         // Just month and year
+         if ( count( $temp ) == 2 )
+      				$date_formatted = array(
+      					"year" => $temp[1],
+      					"month" => $temp[0],
+      					"day" => false
+      				);
+      			// Assuming mm dd yyyy
+      			else
+      				$date_formatted = array(
+      					"year" => $temp[2],
+      					"month" => $temp[0],
+      					"day" => $temp[1]
+      				);
+     } elseif (isset($temp[2])) {
+         // day is set
+         $date_formatted = array(
+     					"year" => $temp[0],
+     					"month" => $temp[1],
+     					"day" => $temp[2]
+     				);
+     } else
+  			{
+  				$date_formatted = array(
+  					"year" => $temp[0],
+  					"month" => $temp[1],
+  					"day" => false
+  				);
+  			}
+ } elseif (strpos( $date, "," )) {
+     $date = trim( str_replace( ", ", ",", $date ) );
+     $temp = preg_split( "/,| /", $date );
+     // Convert month
+     $month = array_search( $temp[0], $list_month_long );
+     if ( !$month ) $month = array_search( $temp[0], $list_month_short );
+     $date_formatted = array(
+   			"year" => $temp[2],
+   			"month" => $month,
+   			"day" => $temp[1]
+   		);
+ } else
 	{
 		$date = trim( str_replace( "  ", "-", $date ) );
 		$temp = explode ( " ", $date );
 
 		// If there's at least two parts to the date
-		if ( count( $temp) > 0 )
+		if ( $temp !== [] )
 		{
 			// Check if name is first
-			if ( !is_numeric( $temp[0] ) )
-			{
-				if ( in_array( $temp[0], $list_month_long ) )
-					$date_formatted = array(
-						"year" => $temp[1],
-						"month" => array_search( $temp[0], $list_month_long ),
-						"day" => false
-					);
-				else if ( in_array( $temp[0], $list_month_short ) )
-					$date_formatted = array(
-						"year" => $temp[1],
-						"month" => array_search( $temp[0], $list_month_short ),
-						"day" => false
-					);
-				else // Not a recognizable month word
-					$date_formatted = array(
-						"year" => $temp[0], // $temp[1]
-						"month" => false,
-						"day" => false
-					);
-			}
-			// Otherwise, check if name is last
-			else
-			{
-				if ( count($temp) > 1 )
-				{
-					if ( in_array( $temp[1], $list_month_long ) )
-						$date_formatted = array(
-							"year" => $temp[0],
-							"month" => array_search( $temp[1], $list_month_long ),
-							"day" => false
-						);
-					else if ( in_array( $temp[1], $list_month_short ) )
-						$date_formatted = array(
-							"year" => $temp[0],
-							"month" => array_search( $temp[1], $list_month_short ),
-							"day" => false
-						);
-					else // Not a recognizable month word
-						$date_formatted = array(
-							"year" => $temp[0],
-							"month" => false,
-							"day" => false
-						);
-				}
-				else // Only one part in the array
+			if (!is_numeric( $temp[0] )) {
+       if (in_array( $temp[0], $list_month_long )) {
+           $date_formatted = array(
+      						"year" => $temp[1],
+      						"month" => array_search( $temp[0], $list_month_long ),
+      						"day" => false
+      					);
+       } elseif (in_array( $temp[0], $list_month_short )) {
+           $date_formatted = array(
+      						"year" => $temp[1],
+      						"month" => array_search( $temp[0], $list_month_short ),
+      						"day" => false
+      					);
+       } else // Not a recognizable month word
+   					$date_formatted = array(
+   						"year" => $temp[0], // $temp[1]
+   						"month" => false,
+   						"day" => false
+   					);
+   } elseif (count($temp) > 1) {
+       if (in_array( $temp[1], $list_month_long )) {
+           $date_formatted = array(
+     							"year" => $temp[0],
+     							"month" => array_search( $temp[1], $list_month_long ),
+     							"day" => false
+     						);
+       } elseif (in_array( $temp[1], $list_month_short )) {
+           $date_formatted = array(
+     							"year" => $temp[0],
+     							"month" => array_search( $temp[1], $list_month_short ),
+     							"day" => false
+     						);
+       } else // Not a recognizable month word
+  						$date_formatted = array(
+  							"year" => $temp[0],
+  							"month" => false,
+  							"day" => false
+  						);
+   } else // Only one part in the array
 				{
 					$date_formatted = array(
 						"year" => $temp[0],
@@ -270,7 +242,6 @@ function zp_date_format ($date)
 						"day" => false
 					);
 				}
-			}
 		}
 
 		// Otherwise, assume year
@@ -311,7 +282,7 @@ function Zotpress_prep_ajax_request_vars()
 
 	// Deal with incoming variables
 	$zpr["type"] = "basic"; if ( isset($_GET['type']) && $_GET['type'] != "" ) $zpr["type"] = $_GET['type'];
-	if ( isset( $_GET['api_user_id'] ) ) $zpr["api_user_id"] = $_GET['api_user_id']; else $zpr["api_user_id"] = false;
+	$zpr["api_user_id"] = isset( $_GET['api_user_id'] ) ? $_GET['api_user_id'] : false;
 	$zpr["item_type"] = "items"; if ( isset($_GET['item_type']) && $_GET['item_type'] != "" ) $zpr["item_type"] = $_GET['item_type'];
 	$zpr["get_top"] = false; if ( isset($_GET['get_top']) ) $zpr["get_top"] = true;
 	$zpr["sub"] = false;
@@ -370,14 +341,14 @@ function Zotpress_prep_ajax_request_vars()
 	$zpr["style"] = zp_Get_Default_Style(); if ( isset($_GET['style']) && $_GET['style'] != "false" && $_GET['style'] != "" && $_GET['style'] != "default" ) $zpr["style"] = $_GET['style'];
 	if ( isset($_GET['limit']) && $_GET['limit'] != 0 )
 	{
-		$zpr["limit"] = intval($_GET['limit']);
+		$zpr["limit"] = (int) $_GET['limit'];
 		$zpr["overwrite_request"] = true;
 	}
 	$zpr["title"] = false; if ( isset($_GET['title']) ) $zpr["title"] = $_GET['title'];
 
 	// Max tags, max results
-	$zpr["maxtags"] = false; if ( isset($_GET['maxtags']) ) $zpr["maxtags"] = intval($_GET['maxtags']);
-	$zpr["maxresults"] = false; if ( isset($_GET['maxresults']) ) $zpr["maxresults"] = intval($_GET['maxresults']);
+	$zpr["maxtags"] = false; if ( isset($_GET['maxtags']) ) $zpr["maxtags"] = (int) $_GET['maxtags'];
+	$zpr["maxresults"] = false; if ( isset($_GET['maxresults']) ) $zpr["maxresults"] = (int) $_GET['maxresults'];
 
 	// Term, filter
 	$zpr["term"] = false; if ( isset($_GET['term']) ) $zpr["term"] = $_GET['term'];
@@ -404,25 +375,18 @@ function Zotpress_prep_ajax_request_vars()
 
 	if ( isset($_GET['sortby']) )
 	{
-		if ( $_GET['sortby'] == "author" )
-		{
-			$zpr["sortby"] = "creator";
-			$zpr["order"] = "asc";
-		}
-		else if ( $_GET['sortby'] == "default" )
-		{
-			$zpr["sortby"] = "default"; // entry order
-		}
-		else if ( $_GET['sortby'] == "year" )
-		{
-			$zpr["sortby"] = "date";
-			$zpr["order"] = "desc";
-		}
-		else if ( $zpr["type"] == "intext" && $_GET['sortby'] == "default" )
-		{
-			$zpr["sortby"] = "default";
-		}
-		else
+		if ($_GET['sortby'] == "author") {
+      $zpr["sortby"] = "creator";
+      $zpr["order"] = "asc";
+  } elseif ($_GET['sortby'] == "default") {
+      $zpr["sortby"] = "default";
+      // entry order
+  } elseif ($_GET['sortby'] == "year") {
+      $zpr["sortby"] = "date";
+      $zpr["order"] = "desc";
+  } elseif ($zpr["type"] == "intext" && $_GET['sortby'] == "default") {
+      $zpr["sortby"] = "default";
+  } else
 		{
 			$zpr["sortby"] = $_GET['sortby'];
 		}
@@ -493,8 +457,8 @@ function Zotpress_prep_ajax_request_vars()
 			&& ( $_GET['forcenumber'] == "yes" || $_GET['forcenumber'] == "true" || $_GET['forcenumber'] === true || $_GET['forcenumber'] == 1 ) )
 		$zpr["forcenumber"] = true;
 
-	$zpr["request_start"] = 0; if ( isset($_GET['request_start']) ) $zpr["request_start"] = intval($_GET['request_start']);
-	$zpr["request_last"] = 0; if ( isset($_GET['request_last']) ) $zpr["request_last"] = intval($_GET['request_last']);
+	$zpr["request_start"] = 0; if ( isset($_GET['request_start']) ) $zpr["request_start"] = (int) $_GET['request_start'];
+	$zpr["request_last"] = 0; if ( isset($_GET['request_last']) ) $zpr["request_last"] = (int) $_GET['request_last'];
 
 	return $zpr;
 
@@ -519,23 +483,16 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 	$tempItemType = "";
 
 	// Get account and $api_user_id
-	if ( $api_user_id )
-    {
-		$zp_account = zp_get_account ($wpdb, $api_user_id);
-	}
-	else
-    {
-		if ( $zpr["api_user_id"] )
-        {
-			$zp_account = zp_get_account ($wpdb, $zpr["api_user_id"]);
-			$api_user_id = $zpr["api_user_id"];
-		}
-		else
-        {
+	if ($api_user_id) {
+     $zp_account = zp_get_account ($wpdb, $api_user_id);
+ } elseif ($zpr["api_user_id"]) {
+     $zp_account = zp_get_account ($wpdb, $zpr["api_user_id"]);
+     $api_user_id = $zpr["api_user_id"];
+ } else
+       {
 			$zp_account = zp_get_account ($wpdb);
 			$api_user_id = $zp_account[0]->api_user_id;
 		}
-	}
 
 	// Make sure account was founded (is synced)
 	if ( count($zp_account) > 0 )
@@ -547,37 +504,30 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 	    if ( $zpr['item_type'] == 'items' )
 	    {
 	    	// Account for single item with new style
-	    	if ( gettype( $zpr["item_key"] ) == "string"
+	    	if (gettype( $zpr["item_key"] ) == "string"
 					&& strlen($zpr["item_key"]) > 0
-	    			&& $zpr["item_key"][0] == "{" )
-	        {
-	    		$zpr_temp = explode(':', $zpr["item_key"]);
-	    		if ( count($zpr_temp) > 1 ) $zpr_temp = $zpr_temp[1];
-	    		else $zpr_temp = $zpr_temp[0];
-	    		$zpr["item_key"] = rtrim( $zpr_temp, "}");
-
-				// Account for page numbers
-				if ( strpos( $zpr["item_key"], ',' ) )
-				{
-					$zpr_temp = explode(',', $zpr["item_key"]);
-					$zpr["item_key"] = rtrim( $zpr_temp[0], "}");
-				}
-	    	}
-	    	// Account for single item in array with new style: remove curly brackets
-	    	else if ( gettype( $zpr["item_key"] ) == "array"
+	    			&& $zpr["item_key"][0] == "{") {
+          $zpr_temp = explode(':', $zpr["item_key"]);
+          $zpr_temp = count($zpr_temp) > 1 ? $zpr_temp[1] : $zpr_temp[0];
+          $zpr["item_key"] = rtrim( $zpr_temp, "}");
+          // Account for page numbers
+          if ( strpos( $zpr["item_key"], ',' ) )
+      				{
+      					$zpr_temp = explode(',', $zpr["item_key"]);
+      					$zpr["item_key"] = rtrim( $zpr_temp[0], "}");
+      				}
+      } elseif (gettype( $zpr["item_key"] ) == "array"
 	    			&& count( $zpr["item_key"] ) == 1
-	    			&& $zpr["item_key"][0][0] == "{" )
-			{
-	    		// $zpr["item_key"] = rtrim( explode(':', $zpr["item_key"][0])[1] , "}");
-	    		$zpr["item_key"] = ltrim( rtrim( $zpr["item_key"][0], "}" ), "{" );
-
-				// Account for page numbers
-				if ( strpos( $zpr["item_key"], ',' ) )
-				{
-					$zpr_temp = explode(',', $zpr["item_key"]);
-					$zpr["item_key"] = rtrim( $zpr_temp[0], "}" );
-				}
-	    	}
+	    			&& $zpr["item_key"][0][0] == "{") {
+          // $zpr["item_key"] = rtrim( explode(':', $zpr["item_key"][0])[1] , "}");
+          $zpr["item_key"] = ltrim( rtrim( $zpr["item_key"][0], "}" ), "{" );
+          // Account for page numbers
+          if ( strpos( $zpr["item_key"], ',' ) )
+      				{
+      					$zpr_temp = explode(',', $zpr["item_key"]);
+      					$zpr["item_key"] = rtrim( $zpr_temp[0], "}" );
+      				}
+      }
 	    } // item type Items
 
 		// Top
@@ -589,29 +539,24 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 					|| strpos($zp_request_queue[$api_user_id]["items"], ',') == false )
 			)
 	    {
-			if ( isset( $zp_request_data["items"] ) )
-			{
-				$zp_import_url .= "/" . $zp_request_data["items"];
-			}
-			else if ( gettype( $zpr["item_key"] ) == "array"
+			if (isset( $zp_request_data["items"] )) {
+       $zp_import_url .= "/" . $zp_request_data["items"];
+   } elseif (gettype( $zpr["item_key"] ) == "array"
 					&& count( $zpr["item_key"] ) == 1
-					&& strpos( $zpr["item_key"][0], ',' ) == false )
-			{
-				$zp_import_url .= "/" . $zpr["item_key"][0];
-			}
-			else if ( gettype( $zpr["item_key"] ) == "string"
+					&& strpos( $zpr["item_key"][0], ',' ) == false) {
+       $zp_import_url .= "/" . $zpr["item_key"][0];
+   } elseif (gettype( $zpr["item_key"] ) == "string"
 					&& ( strpos( $zpr["item_key"], "," ) === false
-				 		&& strpos( $zpr["item_key"], ";" ) === false ) )
-			{
-				$zp_import_url .= "/" . $zpr["item_key"];
-			}
+				 		&& strpos( $zpr["item_key"], ";" ) === false )) {
+       $zp_import_url .= "/" . $zpr["item_key"];
+   }
 	    }
 		if ( $zpr["collection_id"] ) $zp_import_url .= "/" . $zpr["collection_id"];
 		if ( $zpr["sub"] ) $zp_import_url .= "/" . $zpr["sub"];
 		$zp_import_url .= "?";
 
 		// Public key, if needed
-		if (is_null($zp_account[0]->public_key) === false && trim($zp_account[0]->public_key) != "")
+		if (!is_null($zp_account[0]->public_key) && trim($zp_account[0]->public_key) != "")
 			$zp_import_url .= "key=".$zp_account[0]->public_key."&";
 
 		// Style
@@ -646,10 +591,10 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 
 	    		foreach ( $items as $item ) {
 	    			if ( count($request_items) < 50 ) {
-	    				array_push( $request_items, $item );
+	    				$request_items[] = $item;
 	    			}
 	    			else {
-	    				array_push( $requests, $request_items );
+	    				$requests[] = $request_items;
 	    				unset( $request_items );
 	    			}
 	    		}
@@ -691,61 +636,51 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 		// For now, we get all and manually filter below
 		$zp_author_or_year_multiple = false;
 
-		if ( $zpr["collection_id"] || $zpr["tag_id"] )
-		{
-			// Check if author or year is set
-			if ( $zpr["year"] || $zpr["author"] )
-			{
-				// Check if author year is set and multiple
-				if ( ( $zpr["author"] && strpos( $zpr["author"], "," ) !== false )
-						|| ( $zpr["year"] && strpos( $zpr["year"], "," ) !== false ) )
-				{
-					if ( $zpr["author"] && strpos( $zpr["author"], "," ) !== false ) $zp_author_or_year_multiple = "author";
-					else $zp_author_or_year_multiple = "year";
-				}
-				else // Set but not multiple
-				{
-					$zp_import_url .= "&qmode=titleCreatorYear";
-					if ( $zpr["author"] ) $zp_import_url .= "&q=".urlencode( $zpr["author"] );
-					if ( $zpr["year"] && ! $zpr["author"] ) $zp_import_url .= "&q=".$zpr["year"];
-				}
-			}
-		}
-		else // no collection or tag
-		{
-			if ( $zpr["year"] || $zpr["author"] )
-			{
-				$zp_import_url .= "&qmode=titleCreatorYear";
+		if ($zpr["collection_id"] || $zpr["tag_id"]) {
+      // Check if author or year is set
+      if ( $zpr["year"] || $zpr["author"] )
+   			{
+   				// Check if author year is set and multiple
+   				if ( ( $zpr["author"] && strpos( $zpr["author"], "," ) !== false )
+   						|| ( $zpr["year"] && strpos( $zpr["year"], "," ) !== false ) )
+   				{
+   					$zp_author_or_year_multiple = $zpr["author"] && strpos( $zpr["author"], "," ) !== false ? "author" : "year";
+   				}
+   				else // Set but not multiple
+   				{
+   					$zp_import_url .= "&qmode=titleCreatorYear";
+   					if ( $zpr["author"] ) $zp_import_url .= "&q=".urlencode( $zpr["author"] );
+   					if ( $zpr["year"] && ! $zpr["author"] ) $zp_import_url .= "&q=".$zpr["year"];
+   				}
+   			}
+  } elseif ($zpr["year"] || $zpr["author"]) {
+      $zp_import_url .= "&qmode=titleCreatorYear";
+      if ( $zpr["author"] )
+  				{
+  					// REVIEW: Deal with authors with multi-part last names
+  					// Replace plus signs with spaces
+  					if ( strpos( $zpr["author"], "+" ) !== -1 )
+  						$zpr["author"] = str_replace( '+', ' ', $zpr["author"] );
 
-				if ( $zpr["author"] )
-				{
-					// REVIEW: Deal with authors with multi-part last names
-					// Replace plus signs with spaces
-					if ( strpos( $zpr["author"], "+" ) !== -1 )
-						$zpr["author"] = str_replace( '+', ' ', $zpr["author"] );
-
-					if ( $zpr["inclusive"] === false )
-					{
-						$zp_authors = explode( ",", $zpr["author"] );
-						$zp_import_url .= "&q=".urlencode( $zp_authors[0] );
-						unset( $zp_authors[0] );
-						$zpr["author"] = $zp_authors;
-					}
-					else // inclusive
-					{
-						$zp_import_url .= "&q=".urlencode( $zpr["author"] );
-					}
-				}
-
-				// CHANGED (7.3): For some reason, urlencode will replace apostrophes
-				// with &#039; and then encode that to %26%23039%3B
-				// which breaks ... so let's replace with %27 manually
-				$zp_import_url = str_replace("%26%23039%3B", "%27", $zp_import_url);
-
-				// Deal with just year, no author
-				if ( $zpr["year"] && ! $zpr["author"] ) $zp_import_url .= "&q=".$zpr["year"];
-			}
-		}
+  					if ( $zpr["inclusive"] === false )
+  					{
+  						$zp_authors = explode( ",", $zpr["author"] );
+  						$zp_import_url .= "&q=".urlencode( $zp_authors[0] );
+  						unset( $zp_authors[0] );
+  						$zpr["author"] = $zp_authors;
+  					}
+  					else // inclusive
+  					{
+  						$zp_import_url .= "&q=".urlencode( $zpr["author"] );
+  					}
+  				}
+      // CHANGED (7.3): For some reason, urlencode will replace apostrophes
+      // with &#039; and then encode that to %26%23039%3B
+      // which breaks ... so let's replace with %27 manually
+      $zp_import_url = str_replace("%26%23039%3B", "%27", $zp_import_url);
+      // Deal with just year, no author
+      if ( $zpr["year"] && ! $zpr["author"] ) $zp_import_url .= "&q=".$zpr["year"];
+  }
 
 		// Avoid attachments and notes, if not using itemtype filtering
 		if ( ! $zpr["itemtype"]
@@ -763,48 +698,33 @@ function Zotpress_prep_request_URL( $wpdb, $zpr, $zp_request_queue, $api_user_id
 
 		// DEAL WITH MULTIPLE REQUESTS
 		// if ( count($zp_request_queue) > 0 )
-		if ( $zp_request_queue
-				&& array_key_exists($api_user_id, $zp_request_queue) )
-		{
-			// Assume items
-			// if ( array_key_exists("requests", $zp_request_queue[$api_user_id])
-			// 		&& count($zp_request_queue[$api_user_id]["requests"]) > 1 )
-			// Multiple requests
-			if ( array_key_exists("requests", $zp_request_queue[$api_user_id])
-					&& count($zp_request_queue[$api_user_id]["requests"]) > 1 )
-			{
-				$item_keys = "";
-
-				foreach ( $zp_request_queue[$api_user_id]["requests"] as $num => $request ) {
-					if ( $item_keys != "" ) $item_keys .= ",";
-					$item_keys .= $request;
-				}
-
-				$zp_request_queue[$api_user_id]["requests"][$num] = $zp_import_url . "&itemKey=" . $item_keys;
-			}
-			else // one request or less
-			{
-				// Ignore for only one item
-				if ( strpos( $zp_request_queue[$api_user_id]["items"], "," ) !== false )
-				{
-					if ( is_array($zp_request_queue[$api_user_id]["items"]) )
-						$zp_request_queue[$api_user_id]["items"] = implode(",", $zp_request_queue[$api_user_id]["items"]);
-
-					$zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url . "&itemKey=" . $zp_request_queue[$api_user_id]["items"] );
-				}
-				else // one item
-				{
-					$zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url );
-				}
-			}
-		}
-		else if ( ! $zp_request_queue
-				&& $api_user_id )
-		{
-			// Assume normal
-			$zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url );
-		}
-		else
+		if ($zp_request_queue
+				&& array_key_exists($api_user_id, $zp_request_queue)) {
+      // Assume items
+      // if ( array_key_exists("requests", $zp_request_queue[$api_user_id])
+      // 		&& count($zp_request_queue[$api_user_id]["requests"]) > 1 )
+      // Multiple requests
+      if (array_key_exists("requests", $zp_request_queue[$api_user_id])
+   					&& count($zp_request_queue[$api_user_id]["requests"]) > 1) {
+          $item_keys = "";
+          foreach ( $zp_request_queue[$api_user_id]["requests"] as $num => $request ) {
+      					if ( $item_keys != "" ) $item_keys .= ",";
+      					$item_keys .= $request;
+      				}
+          $zp_request_queue[$api_user_id]["requests"][$num] = $zp_import_url . "&itemKey=" . $item_keys;
+      } elseif (strpos( $zp_request_queue[$api_user_id]["items"], "," ) !== false) {
+          if ( is_array($zp_request_queue[$api_user_id]["items"]) )
+     						$zp_request_queue[$api_user_id]["items"] = implode(",", $zp_request_queue[$api_user_id]["items"]);
+          $zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url . "&itemKey=" . $zp_request_queue[$api_user_id]["items"] );
+      } else // one item
+  				{
+  					$zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url );
+  				}
+  } elseif (! $zp_request_queue
+				&& $api_user_id) {
+      // Assume normal
+      $zp_request_queue[$api_user_id]["requests"] = array( $zp_import_url );
+  } else
 		{
 			// Assume broken or no requests
 			$zp_request_queue = false;

--- a/lib/shortcode/shortcode.intext.php
+++ b/lib/shortcode/shortcode.intext.php
@@ -37,8 +37,11 @@ function Zotpress_zotpressInText ($atts)
 
 
     // PREPARE ATTRIBUTES
-    if ( $items )         $items = zpStripQuotes( str_replace(" ", "", $items ));
-    else if ( $item )     $items = zpStripQuotes( str_replace(" ", "", $item ));
+    if ($items) {
+        $items = zpStripQuotes( str_replace(" ", "", $items ));
+    } elseif ($item) {
+        $items = zpStripQuotes( str_replace(" ", "", $item ));
+    }
 
     $pages =              zpStripQuotes( $pages );
     $format =             zpStripQuotes( $format );
@@ -70,22 +73,15 @@ function Zotpress_zotpressInText ($atts)
 
     $zp_account = false;
 
-    if ( $nickname !== false )
-    {
+    if ($nickname !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE nickname='".$nickname."'", OBJECT);
-
         if ( $zp_account !== null )
             $api_user_id = $zp_account->api_user_id;
-    }
-    else if ( $api_user_id !== false )
-    {
+    } elseif ($api_user_id !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$api_user_id."'", OBJECT);
-
         if ( $zp_account !== null )
             $api_user_id = $zp_account->api_user_id;
-    }
-    else if ( $api_user_id === false && $nickname === false )
-    {
+    } elseif ($api_user_id === false && $nickname === false) {
         if ( get_option("Zotpress_DefaultAccount") !== false )
         {
             $api_user_id = get_option("Zotpress_DefaultAccount");
@@ -122,20 +118,13 @@ function Zotpress_zotpressInText ($atts)
     // if ( strpos( $items, $api_user_id ) === false ) // WRONG: assumes default/global api_user_id rather than the one for this shortcode
     if ( strpos( $items, ":" ) === false )
     {
-        if ( strpos( $items, "{" ) !== false )
-        {
+        if (strpos( $items, "{" ) !== false) {
             $items = str_replace( "{", "{".$api_user_id.":", $items );
-        }
-        else // no curly brackets -- so add them!
+        } elseif (strpos( $items, "," ) !== false) {
+            $items = "{".$api_user_id.":" . str_replace( ",", "},{".$api_user_id.":", $items )."}";
+        } else // assume unformatted and single, so place at front
         {
-            if ( strpos( $items, "," ) !== false )
-            {
-                $items = "{".$api_user_id.":" . str_replace( ",", "},{".$api_user_id.":", $items )."}";
-            }
-            else // assume unformatted and single, so place at front
-            {
-                $items = "{".$api_user_id.":".$items."}";
-            }
+            $items = "{".$api_user_id.":".$items."}";
         }
     }
 

--- a/lib/shortcode/shortcode.intextbib.php
+++ b/lib/shortcode/shortcode.intextbib.php
@@ -45,9 +45,11 @@ function Zotpress_zotpressInTextBib ($atts)
     $style = str_replace('"','',html_entity_decode($style));
     $sortby = str_replace('"','',html_entity_decode($sortby));
 
-    if ($order) $order = str_replace('"','',html_entity_decode($order));
-    else if ($sort) $order = str_replace('"','',html_entity_decode($sort));
-    else $order = "asc";
+    if ($order) {
+        $order = str_replace('"','',html_entity_decode($order));
+    } elseif ($sort) {
+        $order = str_replace('"','',html_entity_decode($sort));
+    } else $order = "asc";
     $order = strtolower($order);
 
     // Show image
@@ -55,35 +57,44 @@ function Zotpress_zotpressInTextBib ($atts)
     if ($image) $showimage = str_replace('"','',html_entity_decode($image));
     if ($images) $showimage = str_replace('"','',html_entity_decode($images));
 
-    if ($showimage == "yes" || $showimage == "true" || $showimage === true ) $showimage = true;
-	else if ( $showimage === "openlib") $showimage = "openlib";
-    else $showimage = false;
+    if ($showimage == "yes" || $showimage == "true" || $showimage === true) {
+        $showimage = true;
+    } elseif ($showimage === "openlib") {
+        $showimage = "openlib";
+    } else $showimage = false;
 
     // Show tags
-    if ($showtags == "yes" || $showtags == "true" || $showtags === true) $showtags = true;
-    else $showtags = false;
+    $showtags = $showtags == "yes" || $showtags == "true" || $showtags === true;
 
     $title = str_replace('"','',html_entity_decode($title));
 
-    if ($download) $download = str_replace('"','',html_entity_decode($download));
-    else if ($downloadable) $download = str_replace('"','',html_entity_decode($downloadable));
-    if ($download == "yes" || $download == "true" || $download === true) $download = true; else $download = false;
+    if ($download) {
+        $download = str_replace('"','',html_entity_decode($download));
+    } elseif ($downloadable) {
+        $download = str_replace('"','',html_entity_decode($downloadable));
+    }
+    $download = $download == "yes" || $download == "true" || $download === true;
 
     $shownotes = str_replace('"','',html_entity_decode($notes));
 
-    if ($abstracts) $abstracts = str_replace('"','',html_entity_decode($abstracts));
-    else if ($abstract) $abstracts = str_replace('"','',html_entity_decode($abstract));
+    if ($abstracts) {
+        $abstracts = str_replace('"','',html_entity_decode($abstracts));
+    } elseif ($abstract) {
+        $abstracts = str_replace('"','',html_entity_decode($abstract));
+    }
 
-    if ($citeable) $citeable = str_replace('"','',html_entity_decode($citeable));
-    else if ($cite) $citeable = str_replace('"','',html_entity_decode($cite));
+    if ($citeable) {
+        $citeable = str_replace('"','',html_entity_decode($citeable));
+    } elseif ($cite) {
+        $citeable = str_replace('"','',html_entity_decode($cite));
+    }
 
     if ($target == "new" || $target == "yes" || $target == "_blank" || $target == "true" || $target === true) $target = true;
     else $target = false;
 
-    if ($urlwrap == "title" || $urlwrap == "image" )
-	$urlwrap = str_replace('"','',html_entity_decode($urlwrap)); else $urlwrap = false;
+    $urlwrap = $urlwrap == "title" || $urlwrap == "image" ? str_replace('"','',html_entity_decode($urlwrap)) : false;
 
-    if ($highlight ) $highlight = str_replace('"','',html_entity_decode($highlight)); else $highlight = false;
+    $highlight = $highlight ? str_replace('"','',html_entity_decode($highlight)) : false;
 
     if ($forcenumber == "yes" || $forcenumber == "true" || $forcenumber === true)
         $forcenumber = true;
@@ -199,12 +210,10 @@ function Zotpress_zotpressInTextBib ($atts)
     $zp_output .= Zotpress_shortcode_request( true ); // Check catche first
     $zp_output .= "</div><!-- .zp-zp-SEO-Content -->\n";
 
-    $zp_output .= "</div><!-- .zp-List --></div><!--.zp-Zotpress-->\n\n";
-
 	// Show theme scripts
 	$GLOBALS['zp_is_shortcode_displayed'] = true;
 
-	return $zp_output;
+	return $zp_output . "</div><!-- .zp-List --></div><!--.zp-Zotpress-->\n\n";
 }
 
 ?>

--- a/lib/shortcode/shortcode.lib.php
+++ b/lib/shortcode/shortcode.lib.php
@@ -1,7 +1,7 @@
 <?php
 
 
-require('shortcode.class.lib.php');
+require(__DIR__ . '/shortcode.class.lib.php');
 
 function Zotpress_zotpressLib( $atts )
 {
@@ -51,27 +51,33 @@ function Zotpress_zotpressLib( $atts )
     // FORMAT PARAMETERS
 
     // Filter by account
-    if ($user_id) $api_user_id = str_replace('"','',html_entity_decode($user_id));
-    else if ($userid) $api_user_id = str_replace('"','',html_entity_decode($userid));
-    else $api_user_id = false;
+    if ($user_id) {
+        $api_user_id = str_replace('"','',html_entity_decode($user_id));
+    } elseif ($userid) {
+        $api_user_id = str_replace('"','',html_entity_decode($userid));
+    } else $api_user_id = false;
 
     if ($nickname) $nickname = str_replace('"','',html_entity_decode($nickname));
     if ($nick) $nickname = str_replace('"','',html_entity_decode($nick));
 
 
 	// Type of display
-	if ( $type ) $type = str_replace('"','',html_entity_decode($type)); else $type = "dropdown";
+	$type = $type ? str_replace('"','',html_entity_decode($type)) : "dropdown";
 
     // Filter by collection
-    if ($collection_id) $collection_id = zp_clean_param( $collection_id );
-    else if ($collection) $collection_id = zp_clean_param( $collection );
-    else if ($collections) $collection_id = zp_clean_param( $collections );
-    else if ( isset($_GET['collection_id'])
-            && preg_match("/^[a-zA-Z0-9]+$/", $_GET['collection_id']) )
-       $collection_id = zp_clean_param( $_GET['collection_id'] );
-    else if ( isset($_GET['subcollection_id'])
-            && preg_match("/^[a-zA-Z0-9]+$/", $_GET['subcollection_id']) )
-       $collection_id = zp_clean_param( $_GET['subcollection_id'] );
+    if ($collection_id) {
+        $collection_id = zp_clean_param( $collection_id );
+    } elseif ($collection) {
+        $collection_id = zp_clean_param( $collection );
+    } elseif ($collections) {
+        $collection_id = zp_clean_param( $collections );
+    } elseif (isset($_GET['collection_id'])
+            && preg_match("/^[a-zA-Z0-9]+$/", $_GET['collection_id'])) {
+        $collection_id = zp_clean_param( $_GET['collection_id'] );
+    } elseif (isset($_GET['subcollection_id'])
+            && preg_match("/^[a-zA-Z0-9]+$/", $_GET['subcollection_id'])) {
+        $collection_id = zp_clean_param( $_GET['subcollection_id'] );
+    }
 
 	// Filters
 	if ( $searchby ) $searchby = str_replace('"','',html_entity_decode($searchby));
@@ -117,7 +123,7 @@ function Zotpress_zotpressLib( $atts )
 
     if ( $toplevel ) $toplevel = str_replace('"','',html_entity_decode($toplevel));
 
-    if ( $target && $target != "no" ) $target = true; else $target = false;
+    $target = $target && $target != "no";
 
     if ( $browsebar ) $browsebar = str_replace('"','',html_entity_decode($browsebar));
 
@@ -126,24 +132,15 @@ function Zotpress_zotpressLib( $atts )
 
 	global $wpdb;
 
-    if ($nickname !== false)
-    {
+    if ($nickname !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE nickname='".$nickname."'", OBJECT);
-
-		if ( is_null($zp_account) ): echo "<p>Sorry, but the selected Zotpress nickname can't be found.</p>"; return false; endif;
-
+        if ( is_null($zp_account) ): echo "<p>Sorry, but the selected Zotpress nickname can't be found.</p>"; return false; endif;
         $api_user_id = $zp_account->api_user_id;
-    }
-    else if ($api_user_id !== false)
-    {
+    } elseif ($api_user_id !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$api_user_id."'", OBJECT);
-
-		if ( is_null($zp_account) ): echo $api_user_id."<p>Sorry, but the selected Zotpress account can't be found.</p>"; return false; endif;
-
+        if ( is_null($zp_account) ): echo $api_user_id."<p>Sorry, but the selected Zotpress account can't be found.</p>"; return false; endif;
         $api_user_id = $zp_account->api_user_id;
-    }
-    else if ($api_user_id === false && $nickname === false)
-    {
+    } elseif ($api_user_id === false && $nickname === false) {
         if (get_option("Zotpress_DefaultAccount") !== false)
         {
             $api_user_id = get_option("Zotpress_DefaultAccount");

--- a/lib/shortcode/shortcode.php
+++ b/lib/shortcode/shortcode.php
@@ -1,7 +1,7 @@
 <?php
 
-require('shortcode.functions.php');
-require('shortcode.request.php');
+require(__DIR__ . '/shortcode.functions.php');
+require(__DIR__ . '/shortcode.request.php');
 
 
 function Zotpress_func( $atts )
@@ -80,9 +80,11 @@ function Zotpress_func( $atts )
     // FORMAT & CLEAN PARAMETERS
 
     // Filter by account
-    if ($user_id) $api_user_id = zp_clean_param( $user_id );
-    else if ($userid) $api_user_id = zp_clean_param( $userid );
-    else $api_user_id = false;
+    if ($user_id) {
+        $api_user_id = zp_clean_param( $user_id );
+    } elseif ($userid) {
+        $api_user_id = zp_clean_param( $userid );
+    } else $api_user_id = false;
 
     if ($nickname) $nickname = zp_clean_param( $nickname );
     if ($nick) $nickname = zp_clean_param( $nick );
@@ -92,10 +94,13 @@ function Zotpress_func( $atts )
     if ($authors) $author = zp_clean_param( $authors );
 
     // Filter by year
-    if ( $year ) $year = zp_clean_param( $year );
-    else if ($years) $year = zp_clean_param( $years );
-    else if (strpos($year, ",") > 0) $year = explode(",", $year);
-	else $year = "";
+    if ($year) {
+        $year = zp_clean_param( $year );
+    } elseif ($years) {
+        $year = zp_clean_param( $years );
+    } elseif (strpos($year, ",") > 0) {
+        $year = explode(",", $year);
+    } else $year = "";
 
     // Filter by itemtype
     // TODO: Allow for a list of itemtypes in one shortcode?
@@ -147,28 +152,36 @@ function Zotpress_func( $atts )
         foreach ($officialItemTypes as $type)
             if ( $itemtype == $type ) $itemtypeCheck = true;
 
-        if ( $itemtypeCheck !== true )
+        if ( !$itemtypeCheck )
             $itemtype = false; // Default is no itemtype filter
     }
 
     // Format with datatype and content
-    if ($item_type) $item_type = zp_clean_param( $item_type );
-    else if ($data_type) $item_type = zp_clean_param( $data_type );
-    else $item_type = zp_clean_param( $datatype );
+    if ($item_type) {
+        $item_type = zp_clean_param( $item_type );
+    } elseif ($data_type) {
+        $item_type = zp_clean_param( $data_type );
+    } else $item_type = zp_clean_param( $datatype );
 
     // Filter by collection
-    if ($collection_id) $collection_id = zp_clean_param( $collection_id );
-    else if ($collection) $collection_id = zp_clean_param( $collection );
-    else if ($collections) $collection_id = zp_clean_param( $collections );
+    if ($collection_id) {
+        $collection_id = zp_clean_param( $collection_id );
+    } elseif ($collection) {
+        $collection_id = zp_clean_param( $collection );
+    } elseif ($collections) {
+        $collection_id = zp_clean_param( $collections );
+    }
 	$collection_id = str_replace(" ", "", $collection_id );
 
     if (strpos($collection_id, ",") > 0) $collection_id = explode(",", $collection_id);
     if ($item_type == "collections" && isset($_GET['zpcollection']) ) $collection_id = htmlentities( urldecode( $_GET['zpcollection'] ) );
 
     // Filter by tag
-    if ($tag_name) $tag_id = zp_clean_param( $tag_name );
-    else if ($tags) $tag_id = zp_clean_param( $tags );
-    else $tag_id = zp_clean_param( $tag );
+    if ($tag_name) {
+        $tag_id = zp_clean_param( $tag_name );
+    } elseif ($tags) {
+        $tag_id = zp_clean_param( $tags );
+    } else $tag_id = zp_clean_param( $tag );
 
     $tag_id = str_replace("+", "", $tag_id);
     if (strpos($tag_id, ",") > 0) $tag_id = explode(",", $tag_id);
@@ -183,7 +196,7 @@ function Zotpress_func( $atts )
 	$item_key = str_replace(" ", "", $item_key ); // remove any spaces
 
 	// Inclusive (for multiple authors)
-    if ($inclusive == "yes" || $inclusive == "true" || $inclusive === true ) $inclusive = true; else $inclusive = false;
+    $inclusive = $inclusive == "yes" || $inclusive == "true" || $inclusive === true;
 
     // Format style
     $style = zp_clean_param( $style );
@@ -194,30 +207,35 @@ function Zotpress_func( $atts )
     // Order / sort
     $sortby = zp_clean_param( $sortby );
 
-    if ($order) $order = strtolower(zp_clean_param( $order ));
-    else if ($sort) $order = strtolower(zp_clean_param( $sort ));
+    if ($order) {
+        $order = strtolower(zp_clean_param( $order ));
+    } elseif ($sort) {
+        $order = strtolower(zp_clean_param( $sort ));
+    }
     if ($order === false) $order = "asc";
 
     // Show title
 	// Sorting by secondary sort
     $title = zp_clean_param( $title );
-    if ( $title == "yes" || $title == "true" || $title === true )
+    if ($title == "yes" || $title == "true" || $title === true) {
         $title = "year";
-    else if ( $title == "no" || $title == "false" )
+    } elseif ($title == "no" || $title == "false") {
         $title = false;
+    }
 
     // Show image
     if ($showimage) $showimage = zp_clean_param( $showimage );
     if ($image) $showimage = zp_clean_param( $image );
     if ($images) $showimage = zp_clean_param( $images );
 
-    if ($showimage == "yes" || $showimage == "true" || $showimage === true ) $showimage = true;
-	else if ( $showimage === "openlib") $showimage = "openlib";
-    else $showimage = false;
+    if ($showimage == "yes" || $showimage == "true" || $showimage === true) {
+        $showimage = true;
+    } elseif ($showimage === "openlib") {
+        $showimage = "openlib";
+    } else $showimage = false;
 
     // Show tags
-    if ($showtags == "yes" || $showtags == "true" || $showtags === true) $showtags = true;
-    else $showtags = false;
+    $showtags = $showtags == "yes" || $showtags == "true" || $showtags === true;
 
     // Show download link
     if ($download == "yes" || $download == "true" || $download === true
@@ -225,26 +243,27 @@ function Zotpress_func( $atts )
         $downloadable = true; else $downloadable = false;
 
     // Show notes
-    if ($shownotes) $shownotes = zp_clean_param( $shownotes );
-    else if ($notes) $shownotes = zp_clean_param( $notes );
-    else if ($note) $shownotes = zp_clean_param( $note );
+    if ($shownotes) {
+        $shownotes = zp_clean_param( $shownotes );
+    } elseif ($notes) {
+        $shownotes = zp_clean_param( $notes );
+    } elseif ($note) {
+        $shownotes = zp_clean_param( $note );
+    }
 
-    if ($notes == "yes" || $notes == "true" || $notes === true) $shownotes = true;
-    else $shownotes = false;
+    $shownotes = $notes == "yes" || $notes == "true" || $notes === true;
 
     // Show abstracts
     if ($abstracts) $abstracts = zp_clean_param( $abstracts );
     if ($abstract) $abstracts = zp_clean_param( $abstract );
 
-    if ($abstracts == "yes" || $abstracts == "true" || $abstracts === true) $abstracts = true;
-    else $abstracts = false;
+    $abstracts = $abstracts == "yes" || $abstracts == "true" || $abstracts === true;
 
     // Show cite link
     if ($cite) $citeable = zp_clean_param( $cite );
     if ($citeable) $citeable = zp_clean_param( $citeable );
 
-    if ($citeable == "yes" || $citeable == "true" || $citeable === true) $citeable = true;
-    else $citeable = false;
+    $citeable = $citeable == "yes" || $citeable == "true" || $citeable === true;
 
     if ( ! preg_match("/^[0-9a-zA-Z]+$/", $metadata) ) $metadata = false;
 
@@ -252,10 +271,9 @@ function Zotpress_func( $atts )
     if ($target == "yes" || $target == "_blank" || $target == "new" || $target == "true" || $target === true)
     $target = true; else $target = false;
 
-    if ($urlwrap == "title" || $urlwrap == "image" ) $urlwrap = zp_clean_param( $urlwrap );
-	else $urlwrap = false;
+    $urlwrap = $urlwrap == "title" || $urlwrap == "image" ? zp_clean_param( $urlwrap ) : false;
 
-    if ($highlight ) $highlight = zp_clean_param( $highlight ); else $highlight = false;
+    $highlight = $highlight ? zp_clean_param( $highlight ) : false;
 
     if ( $forcenumber == "yes" || $forcenumber == "true" || $forcenumber === true
             || $forcenumbers == "yes" || $forcenumbers == "true" || $forcenumbers === true )
@@ -276,28 +294,19 @@ function Zotpress_func( $atts )
     // Get account (api_user_id)
     $zp_account = false;
 
-    if ($nickname !== false)
-    {
+    if ($nickname !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE nickname='".$nickname."'", OBJECT);
-
-		if ( is_null($zp_account) ):
-            return "<p>Sorry, but the selected Zotpress nickname can't be found.</p>";
-        endif;
-
+        if ( is_null($zp_account) ):
+                  return "<p>Sorry, but the selected Zotpress nickname can't be found.</p>";
+              endif;
         $api_user_id = $zp_account->api_user_id;
-    }
-    else if ($api_user_id !== false)
-    {
+    } elseif ($api_user_id !== false) {
         $zp_account = $wpdb->get_row("SELECT * FROM ".$wpdb->prefix."zotpress WHERE api_user_id='".$api_user_id."'", OBJECT);
-
-		if ( is_null($zp_account) ):
-            return "<p>Sorry, but the selected Zotpress account can't be found.</p>";
-        endif;
-
+        if ( is_null($zp_account) ):
+                  return "<p>Sorry, but the selected Zotpress account can't be found.</p>";
+              endif;
         $api_user_id = $zp_account->api_user_id;
-    }
-    else if ($api_user_id === false && $nickname === false)
-    {
+    } elseif ($api_user_id === false && $nickname === false) {
         if (get_option("Zotpress_DefaultAccount") !== false)
         {
             $api_user_id = get_option("Zotpress_DefaultAccount");
@@ -311,24 +320,24 @@ function Zotpress_func( $atts )
     }
 
     // Generate instance id for shortcode
-	if ( is_array( $item_key ) ) $temp_item_key = implode( "-", $item_key); else $temp_item_key = $item_key;
-	if ( is_array( $collection_id ) ) $temp_collection_id = implode( "-", $collection_id); else $temp_collection_id = $collection_id;
-	if ( is_array( $tag_id ) ) $temp_tag_name = implode( "-", $tag_id); else $temp_tag_name = $tag_id;
-	if ( is_array( $author ) ) $temp_author = implode( "-", $author); else $temp_author = $author;
-	if ( is_array( $year ) ) $temp_year = implode( "-", $year); else $temp_year = $year;
-	if ( is_array( $sortby ) ) $temp_sortby = implode( "-", $sortby); else $temp_sortby = $sortby;
+	$temp_item_key = is_array( $item_key ) ? implode( "-", $item_key) : $item_key;
+	$temp_collection_id = is_array( $collection_id ) ? implode( "-", $collection_id) : $collection_id;
+	$temp_tag_name = is_array( $tag_id ) ? implode( "-", $tag_id) : $tag_id;
+	$temp_author = is_array( $author ) ? implode( "-", $author) : $author;
+	$temp_year = is_array( $year ) ? implode( "-", $year) : $year;
+	$temp_sortby = is_array( $sortby ) ? implode( "-", $sortby) : $sortby;
 
     // REVIEW: Added post ID
     $instance_id = "zotpress-".md5(get_the_ID().$api_user_id.$nickname.$temp_author.$temp_year.$itemtype.$item_type.$temp_collection_id.$temp_item_key.$temp_tag_name.$style.$temp_sortby.$order.$limit.$showimage.$showtags.$downloadable.$shownotes.$citeable.$inclusive);
 
 	// Prepare item key
-	if ( $item_key ) if ( gettype( $item_key ) != "string" ) $item_key = implode( ",", $item_key );
+	if ( $item_key && gettype( $item_key ) != "string" ) $item_key = implode( ",", $item_key );
 
 	// Prepare collection
-	if ( $collection_id ) if ( gettype( $collection_id ) != "string" ) $collection_id = implode( ",", $collection_id );
+	if ( $collection_id && gettype( $collection_id ) != "string" ) $collection_id = implode( ",", $collection_id );
 
 	// Prepare tags
-	if ( $tag_id ) if ( gettype( $tag_id ) != "string" ) $tag_id = implode( ",", $tag_id );
+	if ( $tag_id && gettype( $tag_id ) != "string" ) $tag_id = implode( ",", $tag_id );
 
     // Set up request vars
     $request_start = 0;
@@ -429,14 +438,12 @@ function Zotpress_func( $atts )
         $zp_output .= "</div><!-- .zp-zp-SEO-Content -->\n";
     }
 
-	$zp_output .= "</div><!-- .zp-List --></div><!--.zp-Zotpress-->\n\n";
-
 
 	// Indicate that shortcode is displayed
 
 	$GLOBALS['zp_is_shortcode_displayed'] = true;
 
-	return $zp_output;
+	return $zp_output . "</div><!-- .zp-List --></div><!--.zp-Zotpress-->\n\n";
 }
 
 ?>

--- a/lib/widget/widget.metabox.php
+++ b/lib/widget/widget.metabox.php
@@ -35,7 +35,7 @@
 				);
 			}
 
-			if (is_null($zp_account[0]->nickname) === false && $zp_account[0]->nickname != "")
+			if (!is_null($zp_account[0]->nickname) && $zp_account[0]->nickname != "")
 				$zp_default_account = $zp_account[0]->nickname . " (" . $zp_account[0]->api_user_id . ")";
 		?>
 		<!-- START OF ACCOUNT -->
@@ -62,7 +62,7 @@
 		                if ( $zp_account[0]->api_user_id == $account->api_user_id )
 		                    echo ' selected="selected"';
 						echo '>';
-		                if (is_null($account->nickname) === false && $account->nickname != "")
+		                if (!is_null($account->nickname) && $account->nickname != "")
 		                    echo $account->nickname . " - ";
 		                echo $account->api_user_id.'</option>';
 		                echo "\n";

--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,14 @@
 === Zotpress ===
-Contributors: kseaborn
+Contributors: kseaborn, kfeuerherm
 Plugin Name: Zotpress
 Plugin URI: http://katieseaborn.com/plugins/
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5HQ8FXAXS9MUQ
 Tags: zotero, zotpress, citation manager, citations, citation, cite, citing, bibliography, bibliographies, reference, referencing, references, reference list, reference manager, academic, academic blogging, academia, scholar, scholarly, scholarly blogging, cv, curriculum vitae, resume, publish, publication, publications
 Author URI: http://katieseaborn.com/
-Author: Katie Seaborn
+Author: Katie Seaborn; this PHP Testing version courtesy of K.G. Feuerherm
 Requires at least: 3.5
 Tested up to: 5.9.3
-Stable tag: 7.3.1.2
+Stable tag: PHP 8 Testing, not proven stable!
 License: Apache2.0
 
 Zotpress displays your Zotero citations on WordPress.

--- a/zotpress.php
+++ b/zotpress.php
@@ -6,7 +6,7 @@
     Plugin URI: http://katieseaborn.com/plugins
     Description: Bringing Zotero and scholarly blogging to your WordPress website.
     Author: Katie Seaborn
-    Version: 7.3.1.2
+    Version: PHP 8 Testing
     Author URI: http://katieseaborn.com
     Text Domain: zotpress
     Domain Path: /languages/
@@ -38,7 +38,7 @@
     define('ZOTPRESS_PLUGIN_FILE',  __FILE__ );
     define('ZOTPRESS_PLUGIN_URL', plugin_dir_url( ZOTPRESS_PLUGIN_FILE ));
     define('ZOTPRESS_PLUGIN_DIR', dirname( __FILE__ ));
-    define('ZOTPRESS_VERSION', '7.3.1.2' );
+    define('ZOTPRESS_VERSION', 'PHP 8 Testing' );
     define('ZOTPRESS_LIVEMODE', true ); // NOTE: Remember to set to TRUE
 
     $GLOBALS['zp_is_shortcode_displayed'] = false;
@@ -153,7 +153,7 @@
 			wp_enqueue_media();
 			wp_enqueue_script( 'jquery.dotimeout.min.js', ZOTPRESS_PLUGIN_URL . 'js/jquery.dotimeout.min.js', array( 'jquery' ) );
 
-			if ( in_array( $hook, array('post.php', 'post-new.php') ) !== true )
+			if ( !in_array( $hook, array('post.php', 'post-new.php') ) )
 			{
 				wp_enqueue_script( 'jquery.livequery.min.js', ZOTPRESS_PLUGIN_URL . 'js/jquery.livequery.min.js', array( 'jquery' ) );
 			}
@@ -178,7 +178,7 @@
         // Turn on/off minified versions if testing/live
         $minify = ''; if ( ZOTPRESS_LIVEMODE ) $minify = '.min';
 
-		if ( strpos( strtolower($hook), "zotpress" ) !== false )
+		if ( stripos( $hook, "zotpress" ) !== false )
 		{
 			wp_enqueue_script( 'zotpress.admin'.$minify.'.js', plugin_dir_url( __FILE__ ) . 'js/zotpress.admin'.$minify.'.js', array( 'jquery','media-upload','thickbox' ) );
 			wp_localize_script(
@@ -263,7 +263,7 @@
     /**
     * Change HTTP request timeout
     */
-    function Zotpress_change_timeout($time) { return 60; /* second */ }
+    function Zotpress_change_timeout($time): int { return 60; /* second */ }
     add_filter('http_request_timeout', 'Zotpress_change_timeout');
 
 


### PR DESCRIPTION
From kfeuerherm [here](https://wordpress.org/support/topic/php-8-1-errors-3/#post-16282984): 

I’m not a PHP expert, but I managed to run the existing plug-in through an updater app (Rector) to bring it to PHP 8.

I’ve set up a test site on my local machine and it seems to work there under PHP 8.0.8.

I make no guarantees and can’t offer support, but if you’d like to try this version and see, here’s the [download link](https://os5.mycloud.com/action/share/8c75d034-048b-4efd-b6ab-f9ae26db5eda) (from my personal NAS cloud).